### PR TITLE
Expose row count in doc

### DIFF
--- a/logging/log_processing/parse.py
+++ b/logging/log_processing/parse.py
@@ -94,6 +94,8 @@ class LogRecord(collections.UserDict):
                                    if k in ["monitor_id", "step", "event", "target", "elapsed"]}
                 if "errors" in monitor_payload:
                     self["monitor"]["error_codes"] = " ".join(error["code"] for error in monitor_payload["errors"])
+                if "extra" in monitor_payload and "rowcount" in monitor_payload["extra"]:
+                    self["monitor"]["rowcount"] = monitor_payload["extra"]["rowcount"]
 
     # Properties to help with updating parser information
 

--- a/logging/log_processing/template.py
+++ b/logging/log_processing/template.py
@@ -71,6 +71,7 @@ LOG_RECORD_MAPPINGS = {
                 "event": {"type": "keyword"},
                 "target": {"type": "keyword"},
                 "elapsed": {"type": "float"},
+                "rowcount": {"type": "long"},
                 "error_codes": {"type": "text"}
             }
         },


### PR DESCRIPTION
Adding `rowcount` to doc to make it easier to search or highlight in Kibana

Finding (new) logs in Kibana with a defined row count:
```
_exists_:monitor.rowcount
```

Example log message from which this is extracted:
```
Monitor payload = {"elapsed":1.635708,"environment":"development","etl_id":"ED173AAB3F434A38","event":"finish","extra":{"destination":{"name":"development","schema":"etl_information","table":"stl_load_errors"},"index":{"current":544,"final":544,"name":"development"},"options":{"skip_copy":false,"use_staging":true},"rowcount":58,"source":{"bucket_name":"BUCKET","object_key":"development/schemas/etl_information/etl_information-stl_load_errors.sql"}},"monitor_id":"43CA6765A6BA45B1","step":"load","target":"etl_information.stl_load_errors","timestamp":"2020-01-02 12:14:16.256681+00:00"}
```