### PR TITLE
Rename index pattern from dw-etl-logs to dw-etl-arthur-logs

### DIFF
--- a/logging/README.md
+++ b/logging/README.md
@@ -150,13 +150,13 @@ config_log delete_stale_indices dev
 
 ## Kibana
 
-In Kibana, add `dw-etl-logs-\*` in **Management** -> **Index Patterns** and select `@timestamp` as the timestamp.
+In Kibana, add `dw-etl-arthur-logs-\*` in **Management** -> **Index Patterns** and select `@timestamp` as the timestamp.
 
 Also, it's probably best to use UTC instead of the browser time, so change in **Management** -> **Advanced Settings**:
 ```text
 dateFormat:tz    UTC
 dateFormat       YYYY/MM/DD HH:mm:ss.SSS
-defaultIndex     dw-etl-logs-*
+defaultIndex     dw-etl-arthur-logs-*
 ```
 
 No further changes should be necessary.

--- a/logging/log_processing/config.py
+++ b/logging/log_processing/config.py
@@ -14,7 +14,7 @@ import requests_aws4auth
 from log_processing import parse
 
 # Index for our log records
-LOG_INDEX_PATTERN = "dw-etl-logs-*"
+LOG_INDEX_PATTERN = "dw-etl-arthur-logs-*"
 LOG_INDEX_TEMPLATE = LOG_INDEX_PATTERN.replace("-*", "-template")
 LOG_DOC_TYPE = "arthur-log"
 OLDEST_INDEX_IN_DAYS = 380


### PR DESCRIPTION
Renaming the index from `dw-etl-logs-<date>` to `dw-etl-arthur-logs-<date>` so that we can more easily 1. add another ETL's logs and 2. distinguish logs (after adding having additional `arthur-` tools send logs into the ES cluster.