### PR TITLE
Better backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # Arthur Tools
 
 We have some tools that we developed originally for [Project Arthur](https://github.com/harrystech/arthur-redshift-etl)
-and then they appeared to more generally useful. So here they are.
+which then appeared to more generally useful. So here they are.
 
 ## Deploying CloudFormation templates
 

--- a/logging/README.md
+++ b/logging/README.md
@@ -32,17 +32,17 @@ See also [How to control access].
 
 In order to run this code locally or to upload it as a lambda function, you have to have a
 virtual environment set up:
-```shell
+```bash
 ../bin/update_virtual_env.sh venv
 ```
 
 To deploy the lambda function, create a package
-```shell
+```bash
 ../bin/create_deployment_package.sh venv
 ```
 
 You need to upload the latest package to S3 in order to use it in the CloudFormation step:
-```shell
+```bash
 aws s3 sync --exclude '*' --include 'log_processing_*.zip' ./ s3://YOUR_CODE_BUCKET/_lambda/
 ```
 
@@ -52,7 +52,7 @@ You can use the included [`dw\_es\_domain.yaml`](./dw_es_domain.yaml) file
 to bring up a ES domain along with a Lambda function to load log files.
 
 For example:
-```shell
+```bash
 ../bin/do_cloudformation.sh create dw_es_domain dev \
     DomainName="dw-es-dev" \
     CodeS3Bucket="<your code bucket>" CodeS3Key="<your latest zip file>" \
@@ -62,7 +62,7 @@ For example:
 Replace the IP address with your actual office IP address.
 
 If you need to update the stack, e.g. to update the Lambda handler, modify this line appropriately:
-```shell
+```bash
 ../bin/do_cloudformation.sh update dw_es_domain dev \
     DomainName=UsePreviousValue \
     CodeS3Bucket=UsePreviousValue CodeS3Key=UsePreviousValue \
@@ -73,7 +73,7 @@ Remember that once you have set an optional parameter, you have to at least pass
 with `=UserPreviousValue` or it reverts to its default.
 
 Finally, to delete the stack, run:
-```shell
+```bash
 ../bin/do_cloudformation.sh delete dw_es_domain dev
 ```
 
@@ -109,7 +109,7 @@ and save it as `notification.json`:
 }
 ```
 
-```shell
+```bash
 aws s3api put-bucket-notification-configuration \
     --bucket "<your bucket>" \
     --notification-configuration file://notification.json
@@ -123,7 +123,7 @@ notification configuration will be replaced.
 Need to pass in the "environment type" which comes from the VPC, like `dev`.
 Sets endpoint for env and also for bucket (so that lambda can use it).
 
-```shell
+```bash
 config_log set_endpoint dev "your bucket" "your endpoint:443"
 config_log get_endpoint dev
 ```
@@ -133,7 +133,7 @@ The endpoint that is used here can be found as an output of the CloudFormation s
 
 If you need to update the index template:
 
-```shell
+```bash
 config_log put_index_template dev
 ```
 The template will be automatically set by the lambda handler with the first call.
@@ -143,7 +143,7 @@ The template will be automatically set by the lambda handler with the first call
 You can review the existing indices and automatically delete those older than about one
 year. (The command will stop to ask for confirmation before actually deleting indices.)
 
-```shell
+```bash
 config_log get_indices dev
 config_log delete_stale_indices dev
 ```
@@ -169,7 +169,7 @@ The individual steps (parsing, compiling, uploading) can be tested locally.
 ## Parsing example log lines
 
 You should be able to run the self-test of the parser:
-```shell
+```bash
 show_log_examples
 ```
 
@@ -179,7 +179,7 @@ In order to test the basic functionality or as a quick check across a number of 
 you can "search" files which will search against the ETL ID, log level and message of every log record.
 
 Examples:
-```shell
+```bash
 # built-in examples
 search_log ERROR examples
 # local files (after you copied some logs from your Arthur run directory)
@@ -194,7 +194,7 @@ You need to pass in the "environment type" which comes from the VPC, like `dev`,
 so that the endpoint address can be looked up in the parameter store.
 
 Example:
-```shell
+```bash
 # built-in examples
 upload_log dev examples
 # local files (after you copied some logs from your Arthur run directory)
@@ -208,7 +208,12 @@ upload_log dev s3://example/logs/df-pipeline-id/component/instance/attempt/StdEr
 In case you find yourself already having log files that are in the bucket but not indexed,
 then you can run the following script to invoke the lambda function:
 
-```shell
-./backfill_logfiles.py "<bucket_name>" "<prefix>" "<function_name>"
+```bash
+./backfill_logfiles.py "<bucket_name>" "<function_name>"
 ```
 Where `<function_name>` may simply be copied from the _Outputs_ section of the CloudFormation stack information.
+
+Check the usage information of the backfill script to see how you can limit which objects are uploaded:
+```bash
+./backfill_logfiles.py --help
+```

--- a/logging/backfill_logfiles.py
+++ b/logging/backfill_logfiles.py
@@ -86,7 +86,7 @@ def main(bucket, prefix, function_name, days_in_past_limit, threads):
     object_keys = list(map(itemgetter(0), sorted(objects, key=itemgetter(1), reverse=True)))
     logging.info("Found {} object(s) to process".format(len(object_keys)))
 
-    logging.info("Starting thread pool (with {} threads".format(threads))
+    logging.info("Starting thread pool with {} thread(s)".format(threads))
     lambda_caller = partial(invoke_log_parser, function_name, bucket)
     with ThreadPoolExecutor(max_workers=threads, thread_name_prefix="lambda_caller") as executor:
         executor.map(lambda_caller, object_keys)

--- a/logging/backfill_logfiles.py
+++ b/logging/backfill_logfiles.py
@@ -7,6 +7,7 @@ This will only load files from stderr (which Arthur uses for its log output).
 """
 
 import argparse
+import base64
 import json
 import logging
 import urllib.parse
@@ -48,19 +49,12 @@ def invoke_log_parser(function_name, bucket_name, object_key):
     """
     logging.info("Invoking log parser for s3://{}/{}".format(bucket_name, object_key))
     payload = {
-        'Records': [
+        "Records": [
             {
                 "eventTime": datetime.utcnow().isoformat(),
                 "eventName": "ObjectCreated:Put",
                 "eventSource": "aws:s3",
-                "s3": {
-                    "bucket": {
-                        "name": bucket_name
-                    },
-                    "object": {
-                        "key": urllib.parse.quote_plus(object_key)
-                    }
-                }
+                "s3": {"bucket": {"name": bucket_name}, "object": {"key": urllib.parse.quote_plus(object_key)}},
             }
         ]
     }
@@ -69,49 +63,51 @@ def invoke_log_parser(function_name, bucket_name, object_key):
 
     try:
         response = client.invoke(
-            FunctionName=function_name,
-            InvocationType='RequestResponse',
-            LogType='Tail',
-            Payload=payload_bytes,
+            FunctionName=function_name, InvocationType="RequestResponse", LogType="Tail", Payload=payload_bytes,
         )
     except Exception:
         logging.exception("Failed to upload 's3://{}/{}':".format(bucket_name, object_key))
         raise
+    logging.info("LogResult={!s}".format(base64.standard_b64decode(response["LogResult"])))
 
-    status_code = response['StatusCode']
+    status_code = response["StatusCode"]
     if status_code == 200:
         logging.info("Finished parsing of 's3://{}/{}' successfully".format(bucket_name, object_key))
     else:
-        logging.warning("Finished parsing of 's3://{}/{}' with status code {}".format(bucket_name, object_key,
-                                                                                      status_code))
+        logging.warning(
+            "Finished parsing of 's3://{}/{}' with status code {}".format(bucket_name, object_key, status_code)
+        )
 
 
 def main(bucket, prefix, function_name, days_in_past_limit, threads):
     logging.info("Attempting to load log files from s3://{}/{} using {}".format(bucket, prefix, function_name))
     logging.info("Arguments that limit objects: prefix={}, days_limit={}".format(prefix, days_in_past_limit))
     objects = list_objects(bucket, prefix, days_in_past_limit)
-    object_keys = map(itemgetter(0), sorted(objects, key=itemgetter(1), reverse=True))
+    object_keys = list(map(itemgetter(0), sorted(objects, key=itemgetter(1), reverse=True)))
     logging.info("Found {} object(s) to process".format(len(object_keys)))
 
     logging.info("Starting thread pool (with {} threads".format(threads))
     lambda_caller = partial(invoke_log_parser, function_name, bucket)
-    with ThreadPoolExecutor(max_workers=threads, thread_name_prefix='lambda_caller') as executor:
+    with ThreadPoolExecutor(max_workers=threads, thread_name_prefix="lambda_caller") as executor:
         executor.map(lambda_caller, object_keys)
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO,
-                        format="%(asctime)s %(levelname)s %(name)s (%(threadName)s) %(message)s")
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s (%(threadName)s) %(message)s")
 
     parser = argparse.ArgumentParser(
         description="Backfill Elasticsearch cluster using log files from the given bucket using the given lambda."
     )
-    parser.add_argument("--prefix",
-                        default="_logs",
-                        help="Limit objects to those with the given prefix (default: %(default)s)")
-    parser.add_argument("--days-limit", type=int,
-                        default=365, metavar="N",
-                        help="Limit objects to those modified within the last N days (default: %(default)s)")
+    parser.add_argument(
+        "--prefix", default="_logs", help="Limit objects to those with the given prefix (default: %(default)s)"
+    )
+    parser.add_argument(
+        "--days-limit",
+        type=int,
+        default=365,
+        metavar="N",
+        help="Limit objects to those modified within the last N days (default: %(default)s)",
+    )
     parser.add_argument("--threads", type=int, default=10, help="Number of threads to use")
     parser.add_argument("bucket", help="Name of bucket in S3")
     parser.add_argument("lambda_arn", help="ARN of Lambda that can process log files")

--- a/logging/backfill_logfiles.py
+++ b/logging/backfill_logfiles.py
@@ -97,6 +97,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         description="Backfill Elasticsearch cluster using log files from the given bucket using the given lambda."
+        " (Tip: To load just one file, specify it as the prefix.)"
     )
     parser.add_argument(
         "--prefix", default="_logs", help="Limit objects to those with the given prefix (default: %(default)s)"

--- a/logging/backfill_logfiles.py
+++ b/logging/backfill_logfiles.py
@@ -6,30 +6,46 @@ Load log files into Elasticsearch domain.
 This will only load files from stderr (which Arthur uses for its log output).
 """
 
+import argparse
 import json
 import logging
-import os.path
-import sys
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from functools import partial
+from operator import itemgetter
 
 import boto3
 
 
-def list_objects(bucket_name, prefix):
+def list_objects(bucket_name, prefix, days_in_past_limit):
+    """
+    Generate list of (object key, modified time) tuples from the bucket.
+
+    The objects returned are limited to those with the prefix which have been modified
+    no more than days_in_past_limit.
+    """
+    earliest = (datetime.utcnow() - timedelta(days=days_in_past_limit)).replace(tzinfo=timezone.utc)
     client = boto3.client("s3")
-    paginator = client.get_paginator('list_objects_v2')
+    paginator = client.get_paginator("list_objects_v2")
     response_iterator = paginator.paginate(Bucket=bucket_name, Prefix=prefix)
+
+    logging.info("Looking for objects that may contain logs...")
     for response in response_iterator:
-        for info in response['Contents']:
+        for info in response["Contents"]:
             # Arthur always logs to the error channel.
-            if info['Key'].endswith(('StdError.gz', 'stderr.gz')):
-                yield info['Key']
+            if info["Key"].endswith(("StdError.gz", "stderr.gz")):
+                if info["LastModified"] > earliest:
+                    yield (info["Key"], info["LastModified"])
 
 
 def invoke_log_parser(function_name, bucket_name, object_key):
+    """
+    Invoke the Lambda function specified by its name or ARN.
+
+    The function will be invoked with an abbreviated S3 event that contains the
+    bucket name and object key information.
+    """
     logging.info("Invoking log parser for s3://{}/{}".format(bucket_name, object_key))
     payload = {
         'Records': [
@@ -48,38 +64,57 @@ def invoke_log_parser(function_name, bucket_name, object_key):
             }
         ]
     }
+    payload_bytes = json.dumps(payload).encode()
+    client = boto3.client("lambda")
+
     try:
-        client = boto3.client("lambda")
         response = client.invoke(
             FunctionName=function_name,
             InvocationType='RequestResponse',
-            LogType='None',
-            Payload=json.dumps(payload).encode()
+            LogType='Tail',
+            Payload=payload_bytes,
         )
-        status_code = response['StatusCode']
-        if status_code == 200:
-            logging.info("Finished parsing of 's3://{}/{}' successfully".format(bucket_name, object_key))
-        else:
-            logging.warning("Finished parsing of 's3://{}/{}' with status code {}".format(bucket_name, object_key,
-                                                                                          status_code))
     except Exception:
         logging.exception("Failed to upload 's3://{}/{}':".format(bucket_name, object_key))
         raise
 
+    status_code = response['StatusCode']
+    if status_code == 200:
+        logging.info("Finished parsing of 's3://{}/{}' successfully".format(bucket_name, object_key))
+    else:
+        logging.warning("Finished parsing of 's3://{}/{}' with status code {}".format(bucket_name, object_key,
+                                                                                      status_code))
 
-def main(bucket, prefix, function_name):
+
+def main(bucket, prefix, function_name, days_in_past_limit, threads):
     logging.info("Attempting to load log files from s3://{}/{} using {}".format(bucket, prefix, function_name))
-    objects = list_objects(bucket, prefix)
-    caller = partial(invoke_log_parser, function_name, bucket)
-    with ThreadPoolExecutor(max_workers=20, thread_name_prefix='lambda_caller') as executor:
-        executor.map(caller, objects)
+    logging.info("Arguments that limit objects: prefix={}, days_limit={}".format(prefix, days_in_past_limit))
+    objects = list_objects(bucket, prefix, days_in_past_limit)
+    object_keys = map(itemgetter(0), sorted(objects, key=itemgetter(1), reverse=True))
+    logging.info("Found {} object(s) to process".format(len(object_keys)))
+
+    logging.info("Starting thread pool (with {} threads".format(threads))
+    lambda_caller = partial(invoke_log_parser, function_name, bucket)
+    with ThreadPoolExecutor(max_workers=threads, thread_name_prefix='lambda_caller') as executor:
+        executor.map(lambda_caller, object_keys)
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4 or (len(sys.argv) > 0 and sys.argv[0] == "-h"):
-        name = os.path.basename(sys.argv[0])
-        print("Usage: {} <bucket_name> <prefix> <function_name>".format(name))
-        sys.exit(0)
     logging.basicConfig(level=logging.INFO,
                         format="%(asctime)s %(levelname)s %(name)s (%(threadName)s) %(message)s")
-    main(*sys.argv[1:4])
+
+    parser = argparse.ArgumentParser(
+        description="Backfill Elasticsearch cluster using log files from the given bucket using the given lambda."
+    )
+    parser.add_argument("--prefix",
+                        default="_logs",
+                        help="Limit objects to those with the given prefix (default: %(default)s)")
+    parser.add_argument("--days-limit", type=int,
+                        default=365, metavar="N",
+                        help="Limit objects to those modified within the last N days (default: %(default)s)")
+    parser.add_argument("--threads", type=int, default=10, help="Number of threads to use")
+    parser.add_argument("bucket", help="Name of bucket in S3")
+    parser.add_argument("lambda_arn", help="ARN of Lambda that can process log files")
+    args = parser.parse_args()
+
+    main(args.bucket, args.prefix, args.lambda_arn, args.days_limit, args.threads)

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="log_processing",
-    version="1.4.0",
+    version="1.5.0",
     author="Harry's Data Engineering and Contributors",
     license="MIT",
     url="https://github.com/harrystech/arthur-tools",


### PR DESCRIPTION
Add option to limit how far back in time the backfill will go to pick up log files. The log files are now also parsed in reverse order, newest file first. Together this allows for quick backfill of most recent data before moving on to older logs.

The parsing of the command line is now using `argparse`, which creates a nice usage info:
```
$ source venv/bin/activate
$ python backfill_logfiles.py -h
usage: backfill_logfiles.py [-h] [--prefix PREFIX] [--days-limit N]
                            [--threads THREADS]
                            bucket lambda_arn

Backfill Elasticsearch cluster using log files from the given bucket using the
given lambda.

positional arguments:
  bucket             Name of bucket in S3
  lambda_arn         ARN of Lambda that can process log files

optional arguments:
  -h, --help         show this help message and exit
  --prefix PREFIX    Limit objects to those with the given prefix (default:
                     _logs)
  --days-limit N     Limit objects to those modified within the last N days
                     (default: 365)
  --threads THREADS  Number of threads to use
```

There are also some formatting changes:
* Using `bash` instead of `shell` in a README file is easier on the eyes in my editor.
* Python code is formatted using the settings from: [Add config for code formatter and linter #15
](https://github.com/harrystech/arthur-tools/pull/15).