### PR TITLE
Switch to json logging

### DIFF
--- a/logging/backfill_logfiles.py
+++ b/logging/backfill_logfiles.py
@@ -34,9 +34,9 @@ def invoke_log_parser(function_name, bucket_name, object_key):
     payload = {
         'Records': [
             {
-                "eventTime": datetime.utcnow().isoformat(),
                 "eventName": "ObjectCreated:Put",
                 "eventSource": "aws:s3",
+                "eventTime": datetime.utcnow().isoformat(),
                 "s3": {
                     "bucket": {
                         "name": bucket_name

--- a/logging/log_processing/compile.py
+++ b/logging/log_processing/compile.py
@@ -7,8 +7,8 @@ log file posted by the data pipelines is automatically drained into an
 Elasticsearch Service pool. That should quench your thirst for log fluids.
 """
 
-import io
 import gzip
+import io
 import sys
 import urllib.parse
 from functools import partial
@@ -49,10 +49,10 @@ def _load_records_using(content_reader, content_location):
 
 def _load_local_content(filename):
     if filename.endswith(".gz"):
-        with gzip.open(filename, 'rb') as f:
+        with gzip.open(filename, "rb") as f:
             lines = f.read().decode()
     else:
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             lines = f.read()
     return lines
 
@@ -61,11 +61,11 @@ def _load_remote_content(uri):
     split_result = urllib.parse.urlsplit(uri)
     if split_result.scheme != "s3":
         raise ValueError("scheme {} not supported".format(split_result.scheme))
-    bucket_name, object_key = split_result.netloc, split_result.path.lstrip('/')
+    bucket_name, object_key = split_result.netloc, split_result.path.lstrip("/")
     s3 = boto3.resource("s3")
     bucket = s3.Bucket(bucket_name)
     obj = bucket.Object(object_key)
-    response = obj.get()['Body']
+    response = obj.get()["Body"]
     if object_key.endswith(".gz"):
         stream = io.BytesIO(response.read())
         lines = gzip.GzipFile(fileobj=stream).read().decode()

--- a/logging/log_processing/config.py
+++ b/logging/log_processing/config.py
@@ -3,9 +3,9 @@ Access to shared settings and managing indices
 """
 
 import argparse
+import datetime
 import sys
 import time
-import datetime
 
 import boto3
 import elasticsearch
@@ -35,7 +35,7 @@ def get_index_name(date=None):
 
 def set_es_endpoint(env_type, bucket_name, endpoint):
     """Set SSM parameters so that lambdas can find the appropriate Elasticsearch cluster."""
-    client = boto3.client('ssm')
+    client = boto3.client("ssm")
     for parameter in (ES_ENDPOINT_BY_ENV_TYPE, ES_ENDPOINT_BY_BUCKET):
         name = parameter.format(env_type=env_type, bucket_name=bucket_name)
         print("Setting parameter '{}'".format(name))
@@ -44,17 +44,10 @@ def set_es_endpoint(env_type, bucket_name, endpoint):
             Description="Value of 'host:port' of Elasticsearch cluster for log processing",
             Value=endpoint,
             Type="String",
-            Overwrite=True
+            Overwrite=True,
         )
         client.add_tags_to_resource(
-            ResourceType="Parameter",
-            ResourceId=name,
-            Tags=[
-                {
-                    "Key": "user:project",
-                    "Value": "data-warehouse"
-                }
-            ]
+            ResourceType="Parameter", ResourceId=name, Tags=[{"Key": "user:project", "Value": "data-warehouse"}]
         )
 
 
@@ -66,22 +59,25 @@ def get_es_endpoint(env_type=None, bucket_name=None):
         name = ES_ENDPOINT_BY_BUCKET.format(bucket_name=bucket_name)
     else:
         raise ValueError("one of 'env_type' or 'bucket_name' must be not None")
-    client = boto3.client('ssm')
+    client = boto3.client("ssm")
     print("Looking up parameter '{}'".format(name))
     response = client.get_parameter(Name=name, WithDecryption=False)
     es_endpoint = response["Parameter"]["Value"]
-    host, port = es_endpoint.rsplit(':', 1)
+    host, port = es_endpoint.rsplit(":", 1)
     return host, int(port)
 
 
 def _aws_auth():
     # https://github.com/sam-washington/requests-aws4auth/pull/2
     session = boto3.Session()
-    print("Retrieving credentials (profile_name={}, region_name={})".format(session.profile_name, session.region_name),
-          file=sys.stderr)
+    print(
+        "Retrieving credentials (profile_name={}, region_name={})".format(session.profile_name, session.region_name),
+        file=sys.stderr,
+    )
     credentials = session.get_credentials()
-    aws4auth = requests_aws4auth.AWS4Auth(credentials.access_key, credentials.secret_key, session.region_name, "es",
-                                          session_token=credentials.token)
+    aws4auth = requests_aws4auth.AWS4Auth(
+        credentials.access_key, credentials.secret_key, session.region_name, "es", session_token=credentials.token
+    )
 
     def wrapped_aws4auth(request):
         return aws4auth(request)
@@ -103,7 +99,7 @@ def connect_to_es(host, port, use_auth=False):
         verify_certs=True,
         connection_class=elasticsearch.connection.RequestsHttpConnection,
         http_auth=http_auth,
-        send_get_body_as="POST"
+        send_get_body_as="POST",
     )
     return es
 
@@ -117,13 +113,8 @@ def put_index_template(client):
     body = {
         "template": LOG_INDEX_PATTERN,
         "version": version,
-        "settings": {
-            "number_of_shards": 2,
-            "number_of_replicas": 1
-        },
-        "mappings": {
-            "properties": parse.LogRecord.index_properties()
-        }
+        "settings": {"number_of_shards": 2, "number_of_replicas": 1},
+        "mappings": {"properties": parse.LogRecord.index_properties()},
     }
     print("Updating index template '{}' (version={})".format(LOG_INDEX_TEMPLATE_NAME, version))
     client.indices.put_template(LOG_INDEX_TEMPLATE_NAME, body)
@@ -208,10 +199,10 @@ def sub_delete_stale_indices(args):
     try:
         proceed = input("Proceed to delete old indices? (y/[n]) ")
     except EOFError:
-        proceed = 'n'
-    if proceed.lower() in ('y', 'yes'):
+        proceed = "n"
+    if proceed.lower() in ("y", "yes"):
         print("Ok, deleting old indices.")
-        es.indices.delete(','.join(sorted(stale)))
+        es.indices.delete(",".join(sorted(stale)))
 
 
 def main():

--- a/logging/log_processing/config.py
+++ b/logging/log_processing/config.py
@@ -74,10 +74,7 @@ def get_es_endpoint(env_type=None, bucket_name=None):
 def _aws_auth():
     # https://github.com/sam-washington/requests-aws4auth/pull/2
     session = boto3.Session()
-    logger.info(
-        f"Retrieving credentials (profile_name={session.profile_name}, region_name={session.region_name})",
-        file=sys.stderr,
-    )
+    logger.info(f"Retrieving credentials (profile_name={session.profile_name}, region_name={session.region_name})",)
     credentials = session.get_credentials()
     aws4auth = requests_aws4auth.AWS4Auth(
         credentials.access_key, credentials.secret_key, session.region_name, "es", session_token=credentials.token

--- a/logging/log_processing/config.py
+++ b/logging/log_processing/config.py
@@ -22,7 +22,7 @@ ES_ENDPOINT_BY_ENV_TYPE = "/DW-ETL/ES-By-Env-Type/{env_type}"
 ES_ENDPOINT_BY_BUCKET = "/DW-ETL/ES-By-Bucket/{bucket_name}"
 
 
-def log_index(date=None):
+def get_index_name(date=None):
     """Return name of index for current date (or specified date) with granularity of a day."""
     if date is None:
         instant = datetime.date.today()
@@ -138,7 +138,7 @@ def get_current_indices(client):
 
 def get_active_indices():
     today = datetime.datetime.utcnow()
-    names = [log_index(today - datetime.timedelta(days=days)) for days in range(0, OLDEST_INDEX_IN_DAYS)]
+    names = [get_index_name(today - datetime.timedelta(days=days)) for days in range(0, OLDEST_INDEX_IN_DAYS)]
     return sorted(names)
 
 

--- a/logging/log_processing/json_logging.py
+++ b/logging/log_processing/json_logging.py
@@ -60,8 +60,8 @@ class JsonFormatter(logging.Formatter):
 
     converter = time.gmtime
 
-    # The map either specifies the name to be used or None if attributed will be suppressed.
     attribute_mapping = {
+        # LogRecord attributes for which we want new names:
         "funcName": "source.function",
         "levelname": "log_level",
         "levelno": "log_severity",
@@ -72,6 +72,11 @@ class JsonFormatter(logging.Formatter):
         "process": "process.id",
         "processName": "process.name",
         "threadName": "thread.name",
+        # Common context attributes which we want to rename:
+        "function_name": "lambda.function_name",
+        "function_version": "lambda.function_version",
+        "log_stream_name": "cwl.log_stream_name",
+        # LogRecord attributes which we want to suppress:
         "args": None,
         "created": None,
         "msecs": None,

--- a/logging/log_processing/json_logging.py
+++ b/logging/log_processing/json_logging.py
@@ -1,0 +1,126 @@
+"""
+Enable logging (from Lambdas) in JSON format which makes post-processing much easier.
+
+Since we assume this will be used by Lambdas, we also add the request id in log lines.
+"""
+
+import json
+import logging
+import logging.config
+import time
+
+
+class ContextFilter(logging.Filter):
+    """
+    Logging Filter class that adds contextual information to log records.
+
+    We assume there will be only one instance of this filter for any runtime which
+    means that we will store some values with the class, not the instances.
+    """
+
+    aws_request_id = None
+    function_name = None
+    function_version = None
+    log_group_name = None
+    log_stream_name = None
+
+    def filter(self, record):
+        """
+        Modify record in place for additional fields, then return True to continue processing.
+        """
+        record.aws_request_id = self.aws_request_id
+        record.function_name = self.function_name
+        record.function_version = self.function_version
+        record.log_group_name = self.log_group_name
+        record.log_stream_name = self.log_stream_name
+        return True
+
+    @classmethod
+    def update_context(cls, **kwargs):
+        """
+        Update any of the fields stored in the (global) context filter.
+
+        Note that this doesn't set fields not already defined.
+        It is ok to pass in args that are unknown -- they are ignored.
+        """
+        for key, value in kwargs.items():
+            if hasattr(cls, key):
+                setattr(cls, key, value)
+
+
+class JsonFormatter(logging.Formatter):
+    """
+    Format the message to be easily reverted into an object by using JSON format.
+
+    Notes:
+        * The "format" is ignored since we convert based on available info.
+        * The timestamps are in UTC.
+    """
+
+    converter = time.gmtime
+
+    # The map either specifies the name to be used or None if attributed will be suppressed.
+    attribute_mapping = {
+        "levelname": "level_name",
+        "name": "logger",
+        "args": None,
+        "created": None,
+        "msecs": None,
+        "msg": None,
+        "relativeCreated": None,
+        "thread": None,
+    }
+
+    def format(self, record):
+        data = {}
+        for attr, value in record.__dict__.items():
+            if value is None:
+                continue
+            if attr in self.attribute_mapping:
+                new_name = self.attribute_mapping[attr]
+                if new_name is not None:
+                    data[new_name] = value
+            else:
+                data[attr] = value
+        # The "message" is added last so an accidentally specified message in the extra kwargs is ignored.
+        data["message"] = record.getMessage()
+        return json.dumps(data, separators=(",", ":"), sort_keys=True)
+
+
+# We don't create the config dict until here so that we can use the classes (instead of class names in strings).
+LOGGING_STREAM_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {"json_formatter": {"()": JsonFormatter},},
+    "filters": {"context_filter": {"()": ContextFilter},},
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+            "formatter": "json_formatter",
+            "filters": ["context_filter"],
+            "stream": "ext://sys.stdout",
+        }
+    },
+    "root": {"level": "INFO", "handlers": ["console"]},
+}
+
+
+def configure_logging():
+    logging.config.dictConfig(LOGGING_STREAM_CONFIG)
+
+
+# For convenience to avoid too many logging imports.
+def getLogger(name):
+    return logging.getLogger(name)
+
+
+def update_context(**kwargs):
+    ContextFilter.update_context(**kwargs)
+
+
+if __name__ == "__main__":
+    configure_logging()
+    update_context(request_id="62E538E9-E9C5-415A-9771-6588F9A1A708")
+
+    logging.info("Message at INFO level", extra={"stuff": "more"})

--- a/logging/log_processing/json_logging.py
+++ b/logging/log_processing/json_logging.py
@@ -91,8 +91,8 @@ class JsonFormatter(logging.Formatter):
 LOGGING_STREAM_CONFIG = {
     "version": 1,
     "disable_existing_loggers": False,
-    "formatters": {"json_formatter": {"()": JsonFormatter},},
-    "filters": {"context_filter": {"()": ContextFilter},},
+    "formatters": {"json_formatter": {"()": JsonFormatter}},
+    "filters": {"context_filter": {"()": ContextFilter}},
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
@@ -103,6 +103,7 @@ LOGGING_STREAM_CONFIG = {
         }
     },
     "root": {"level": "INFO", "handlers": ["console"]},
+    "loggers": {"botocore": {"qualname": "botocore", "handlers": ["console"], "level": "WARNING", "propagate": 0}},
 }
 
 

--- a/logging/log_processing/parse.py
+++ b/logging/log_processing/parse.py
@@ -91,7 +91,7 @@ class LogRecord(collections.UserDict):
             try:
                 monitor_payload = json.loads(payload_text)
             except json.decoder.JSONDecodeError as exc:
-                print("Partial monitor payload detected in '{}': {}".format(payload_text, exc))
+                print(f"Partial monitor payload detected in '{payload_text}': {exc}")
             else:
                 self["monitor"] = {
                     k: v

--- a/logging/log_processing/template.py
+++ b/logging/log_processing/template.py
@@ -1,23 +1,16 @@
 LOG_RECORD_PROPERTIES = {
     "application_name": {"type": "keyword"},
     "environment": {"type": "keyword"},
-    "logfile": {
-        "type": "keyword",
-    },
+    "logfile": {"type": "keyword",},
     "data_pipeline": {
         "properties": {
             "id": {"type": "keyword"},
             "component": {"type": "keyword"},
             "instance": {"type": "keyword"},
-            "attempt": {"type": "keyword"}
+            "attempt": {"type": "keyword"},
         }
     },
-    "emr_cluster": {
-        "properties": {
-            "id": {"type": "keyword"},
-            "step_id": {"type": "keyword"}
-        }
-    },
+    "emr_cluster": {"properties": {"id": {"type": "keyword"}, "step_id": {"type": "keyword"},}},
     "@timestamp": {"type": "date", "format": "strict_date_optional_time"},  # generic ISO datetime parser
     "datetime": {
         "properties": {
@@ -29,39 +22,18 @@ LOG_RECORD_PROPERTIES = {
             "day_of_week": {"type": "integer"},
             "hour": {"type": "integer"},
             "minute": {"type": "integer"},
-            "second": {"type": "integer"}
+            "second": {"type": "integer"},
         },
     },
     "etl_id": {"type": "keyword"},
     "log_level": {"type": "keyword"},
-    "logger": {
-        "type": "text",
-        "analyzer": "simple",
-        "fields": {
-            "name": {
-                "type": "keyword"
-            }
-        }
-    },
+    "logger": {"type": "text", "analyzer": "simple", "fields": {"name": {"type": "keyword"}},},
     "thread_name": {"type": "keyword"},
-    "source_code": {
-        "properties": {
-            "filename": {"type": "text"},
-            "line_number": {"type": "integer"},
-        }
-    },
+    "source_code": {"properties": {"filename": {"type": "text"}, "line_number": {"type": "integer"},}},
     "message": {
         "type": "text",
         "analyzer": "standard",
-        "fields": {
-            "raw": {
-                "type": "keyword"
-            },
-            "english": {
-                "type": "text",
-                "analyzer": "english"
-            }
-        }
+        "fields": {"raw": {"type": "keyword"}, "english": {"type": "text", "analyzer": "english",}},
     },
     "monitor": {
         "properties": {
@@ -71,25 +43,8 @@ LOG_RECORD_PROPERTIES = {
             "target": {"type": "keyword"},
             "elapsed": {"type": "float"},
             "rowcount": {"type": "long"},
-            "error_codes": {"type": "text"}
+            "error_codes": {"type": "text"},
         }
     },
-    "parser": {
-        "properties": {
-            "start_pos": {"type": "long"},
-            "end_pos": {"type": "long"},
-            "chars": {"type": "long"}
-        },
-    },
-    # These last properties are only used by the Lambda handler:
-    "lambda_name": {"type": "keyword"},
-    "lambda_version": {"type": "keyword"},
-    "context": {
-        "properties": {
-            "remaining_time_in_millis": {"type": "long"}
-        }
-    },
-    "original_logfile": {
-        "type": "keyword",
-    }
+    "parser": {"properties": {"start_pos": {"type": "long"}, "end_pos": {"type": "long"}, "chars": {"type": "long"},}},
 }

--- a/logging/log_processing/template.py
+++ b/logging/log_processing/template.py
@@ -1,7 +1,7 @@
 LOG_RECORD_PROPERTIES = {
     "application_name": {"type": "keyword"},
     "environment": {"type": "keyword"},
-    "logfile": {"type": "keyword",},
+    "logfile": {"type": "keyword"},
     "data_pipeline": {
         "properties": {
             "id": {"type": "keyword"},
@@ -10,7 +10,7 @@ LOG_RECORD_PROPERTIES = {
             "attempt": {"type": "keyword"},
         }
     },
-    "emr_cluster": {"properties": {"id": {"type": "keyword"}, "step_id": {"type": "keyword"},}},
+    "emr_cluster": {"properties": {"id": {"type": "keyword"}, "step_id": {"type": "keyword"}}},
     "@timestamp": {"type": "date", "format": "strict_date_optional_time"},  # generic ISO datetime parser
     "datetime": {
         "properties": {
@@ -27,13 +27,13 @@ LOG_RECORD_PROPERTIES = {
     },
     "etl_id": {"type": "keyword"},
     "log_level": {"type": "keyword"},
-    "logger": {"type": "text", "analyzer": "simple", "fields": {"name": {"type": "keyword"}},},
+    "logger": {"type": "text", "analyzer": "simple", "fields": {"name": {"type": "keyword"}}},
     "thread_name": {"type": "keyword"},
-    "source_code": {"properties": {"filename": {"type": "text"}, "line_number": {"type": "integer"},}},
+    "source_code": {"properties": {"filename": {"type": "text"}, "line_number": {"type": "integer"}}},
     "message": {
         "type": "text",
         "analyzer": "standard",
-        "fields": {"raw": {"type": "keyword"}, "english": {"type": "text", "analyzer": "english",}},
+        "fields": {"raw": {"type": "keyword"}, "english": {"type": "text", "analyzer": "english"}},
     },
     "monitor": {
         "properties": {
@@ -46,5 +46,5 @@ LOG_RECORD_PROPERTIES = {
             "error_codes": {"type": "text"},
         }
     },
-    "parser": {"properties": {"start_pos": {"type": "long"}, "end_pos": {"type": "long"}, "chars": {"type": "long"},}},
+    "parser": {"properties": {"start_pos": {"type": "long"}, "end_pos": {"type": "long"}, "chars": {"type": "long"}}},
 }

--- a/logging/log_processing/upload.py
+++ b/logging/log_processing/upload.py
@@ -16,13 +16,15 @@ import botocore.exceptions
 import elasticsearch
 import elasticsearch.helpers
 
-from log_processing import compile, config, parse
+from log_processing import compile, config, json_logging, parse
+
+# This is done during module initialization so that it is done once for a Lambda runtime environment.
+json_logging.configure_logging()
+logger = json_logging.getLogger(__name__)
 
 
 def _build_actions_from(index, records):
     for record in records:
-        if record["logfile"] == "examples":
-            print("Example record ... _id={0.id_} timestamp={0[@timestamp]}".format(record))
         yield {
             "_op_type": "index",
             "_index": index,
@@ -32,19 +34,20 @@ def _build_actions_from(index, records):
 
 
 def index_records(es, records_generator):
-    n_ok, n_errors = 0, 0
+    """
+    Bulk-index log records. The appropriate index is chosen given the date of the log record.
+    """
     for date, records in itertools.groupby(records_generator, key=lambda rec: rec["datetime"]["date"]):
         index = config.get_index_name(date)
-        print("Indexing records into '{}'".format(index))
-        ok, errors = elasticsearch.helpers.bulk(es, _build_actions_from(index, records))
-        n_ok += ok
+        n_errors = 0
+        n_ok, errors = elasticsearch.helpers.bulk(es, _build_actions_from(index, records))
         if errors:
-            print("Errors: {}".format(errors))
-            n_errors += len(errors)
-    print("Indexed successfully: {:d}, unsuccessfully: {:d}".format(n_ok, n_errors))
+            logger.warning(f"Index errors: {errors}")
+            n_errors = len(errors)
+        logger.info(f"Indexed successfully={n_ok:d}, unsuccessfully={n_errors:d}, index={index}")
 
 
-def lambda_handler(event, _):
+def lambda_handler(event, context):
     """
     Callback handler for Lambda.
 
@@ -63,34 +66,46 @@ def lambda_handler(event, _):
         ]
     }
     """
+    json_logging.update_context(
+        aws_request_id=context.aws_request_id,
+        function_name=context.function_name,
+        function_version=context.function_version,
+        log_stream_name=context.log_stream_name,
+    )
     for i, event_data in enumerate(event["Records"]):
+        logger.info(
+            "Event #{i}: source={eventSource}, name={eventName}, time={eventTime}".format(i=i, **event_data),
+            extra={"event_source": event_data["eventSource"], "event_name": event_data["eventName"],},
+        )
         bucket_name = event_data["s3"]["bucket"]["name"]
         object_key = urllib.parse.unquote_plus(event_data["s3"]["object"]["key"])
-        print(
-            "Event #{:d}: source={}, event={}, time={}, bucket={}, key={}".format(
-                i, event_data["eventSource"], event_data["eventName"], event_data["eventTime"], bucket_name, object_key
-            )
-        )
-
-        if not (object_key.startswith("_logs/") or "/logs/" in object_key):
-            print("Path is not in log folder: skipping this object")
-            return
+        is_log_file = object_key.startswith("_logs/") or "/logs/" in object_key
+        logger.info(f"Bucket={bucket_name}, object={object_key}, is_log_file={is_log_file}")
+        if not is_log_file:
+            continue
 
         file_uri = "s3://{}/{}".format(bucket_name, object_key)
+        try:
+            processed = compile.load_records([file_uri])
+        except parse.NoRecordsFoundError:
+            logger.info("Failed to find log records in object '{}'".format(file_uri))
+            continue
+
         try:
             host, port = config.get_es_endpoint(bucket_name=bucket_name)
             es = config.connect_to_es(host, port, use_auth=True)
             if not config.exists_index_template(es):
                 config.put_index_template(es)
-            processed = compile.load_records([file_uri])
+        except botocore.exceptions.ClientError as exc:
+            logger.warning(f"Failed in initial connection: {exc!s}")
+            continue
+
+        try:
             index_records(es, processed)
-        except parse.NoRecordsFoundError:
-            print("Failed to find log records in object '{}'".format(file_uri))
-            return
         except botocore.exceptions.ClientError as exc:
             error_code = exc.response["Error"]["Code"]
-            print("Error code {} for object '{}'".format(error_code, file_uri))
-            return
+            logger.warning(f"Error code {error_code} for object '{file_uri}'")
+            continue
 
 
 def main():

--- a/logging/log_processing/upload.py
+++ b/logging/log_processing/upload.py
@@ -75,7 +75,11 @@ def lambda_handler(event, context):
     for i, event_data in enumerate(event["Records"]):
         logger.info(
             "Event #{i}: source={eventSource}, name={eventName}, time={eventTime}".format(i=i, **event_data),
-            extra={"event_source": event_data["eventSource"], "event_name": event_data["eventName"]},
+            extra={
+                "event.source": event_data["eventSource"],
+                "event.name": event_data["eventName"],
+                "event.time": event_data["eventTime"],
+            },
         )
         bucket_name = event_data["s3"]["bucket"]["name"]
         object_key = urllib.parse.unquote_plus(event_data["s3"]["object"]["key"])

--- a/logging/log_processing/upload.py
+++ b/logging/log_processing/upload.py
@@ -85,11 +85,7 @@ def lambda_handler(event, context):
             continue
 
         file_uri = "s3://{}/{}".format(bucket_name, object_key)
-        try:
-            processed = compile.load_records([file_uri])
-        except parse.NoRecordsFoundError:
-            logger.info("Failed to find log records in object '{}'".format(file_uri))
-            continue
+        processed = compile.load_records([file_uri])
 
         try:
             host, port = config.get_es_endpoint(bucket_name=bucket_name)
@@ -102,6 +98,9 @@ def lambda_handler(event, context):
 
         try:
             index_records(es, processed)
+        except parse.NoRecordsFoundError:
+            logger.info("Failed to find log records in object '{}'".format(file_uri))
+            continue
         except botocore.exceptions.ClientError as exc:
             error_code = exc.response["Error"]["Code"]
             logger.warning(f"Error code {error_code} for object '{file_uri}'")

--- a/logging/log_processing/upload.py
+++ b/logging/log_processing/upload.py
@@ -75,7 +75,7 @@ def lambda_handler(event, context):
     for i, event_data in enumerate(event["Records"]):
         logger.info(
             "Event #{i}: source={eventSource}, name={eventName}, time={eventTime}".format(i=i, **event_data),
-            extra={"event_source": event_data["eventSource"], "event_name": event_data["eventName"],},
+            extra={"event_source": event_data["eventSource"], "event_name": event_data["eventName"]},
         )
         bucket_name = event_data["s3"]["bucket"]["name"]
         object_key = urllib.parse.unquote_plus(event_data["s3"]["object"]["key"])

--- a/logging/log_processing/upload.py
+++ b/logging/log_processing/upload.py
@@ -63,11 +63,14 @@ def lambda_handler(event, _):
         ]
     }
     """
-    for i, event_data in enumerate(event['Records']):
-        bucket_name = event_data['s3']['bucket']['name']
-        object_key = urllib.parse.unquote_plus(event_data['s3']['object']['key'])
-        print("Event #{:d}: source={}, event={}, time={}, bucket={}, key={}".format(
-            i, event_data['eventSource'], event_data['eventName'], event_data['eventTime'], bucket_name, object_key))
+    for i, event_data in enumerate(event["Records"]):
+        bucket_name = event_data["s3"]["bucket"]["name"]
+        object_key = urllib.parse.unquote_plus(event_data["s3"]["object"]["key"])
+        print(
+            "Event #{:d}: source={}, event={}, time={}, bucket={}, key={}".format(
+                i, event_data["eventSource"], event_data["eventName"], event_data["eventTime"], bucket_name, object_key
+            )
+        )
 
         if not (object_key.startswith("_logs/") or "/logs/" in object_key):
             print("Path is not in log folder: skipping this object")
@@ -85,7 +88,7 @@ def lambda_handler(event, _):
             print("Failed to find log records in object '{}'".format(file_uri))
             return
         except botocore.exceptions.ClientError as exc:
-            error_code = exc.response['Error']['Code']
+            error_code = exc.response["Error"]["Code"]
             print("Error code {} for object '{}'".format(error_code, file_uri))
             return
 

--- a/logging/log_processing/upload.py
+++ b/logging/log_processing/upload.py
@@ -82,7 +82,7 @@ def lambda_handler(event, _):
             es = config.connect_to_es(host, port, use_auth=True)
             if not config.exists_index_template(es):
                 config.put_index_template(es)
-            processed = compile.load_records(file_uri)
+            processed = compile.load_records([file_uri])
             index_records(es, processed)
         except parse.NoRecordsFoundError:
             print("Failed to find log records in object '{}'".format(file_uri))

--- a/logging/log_processing/upload.py
+++ b/logging/log_processing/upload.py
@@ -106,6 +106,8 @@ def lambda_handler(event, context):
             logger.warning(f"Error code {error_code} for object '{file_uri}'")
             continue
 
+        logger.info("Indexed log records successfully.", extra={"log_file_uri": file_uri})
+
 
 def main():
     if len(sys.argv) < 3:


### PR DESCRIPTION
This adds a logging formatter that sends JSON-formatted log records to the output.

Example:
```
$ python log_processing/json_logging.py | json_pp
{
   "stuff" : "more",
   "gmtime" : "2020-02-17T20:41:58.876Z",
   "source.module" : "json_logging",
   "source.pathname" : "log_processing/json_logging.py",
   "log_level" : "INFO",
   "aws_request_id" : "62E538E9-E9C5-415A-9771-6588F9A1A708",
   "message" : "Message at INFO level",
   "log_severity" : 20,
   "logger" : "root",
   "process.name" : "MainProcess",
   "source.function" : "<module>",
   "process.id" : 18256,
   "thread.name" : "MainThread",
   "source.line_number" : 148,
   "source:filename" : "json_logging.py"
}
```

Python code is formatted using the settings from: [Add config for code formatter and linter #15
](https://github.com/harrystech/arthur-tools/pull/15).