### PR TITLE
Add config for code formatter and linter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+include = '\.pyi?$'
+line-length = 120
+target-version = ['py36']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[pycodestyle]
+# Seetings are compatible with black, see https://github.com/psf/black/issues/354
+ignore = E203,W503
+# This is the current setting for this project. We may want to think to drop to 88.
+max-line-length = 120


### PR DESCRIPTION
Initial commit to add support for
* Formatting code using `black`
* Sorting imports using `isort`
* Linting code using `pycodestyle`