### PR TITLE
Apply black and isort to log_processing

### DIFF
--- a/logging/log_processing/compile.py
+++ b/logging/log_processing/compile.py
@@ -7,8 +7,8 @@ log file posted by the data pipelines is automatically drained into an
 Elasticsearch Service pool. That should quench your thirst for log fluids.
 """
 
-import io
 import gzip
+import io
 import sys
 import urllib.parse
 from functools import partial
@@ -48,10 +48,10 @@ def _load_records_using(content_opener, content_location):
 
 def load_local_content(filename):
     if filename.endswith(".gz"):
-        with gzip.open(filename, 'rb') as f:
+        with gzip.open(filename, "rb") as f:
             lines = f.read().decode()
     else:
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             lines = f.read()
     return lines
 
@@ -60,11 +60,11 @@ def load_remote_content(uri):
     split_result = urllib.parse.urlsplit(uri)
     if split_result.scheme != "s3":
         raise ValueError("scheme {} not supported".format(split_result.scheme))
-    bucket_name, object_key = split_result.netloc, split_result.path.lstrip('/')
+    bucket_name, object_key = split_result.netloc, split_result.path.lstrip("/")
     s3 = boto3.resource("s3")
     bucket = s3.Bucket(bucket_name)
     obj = bucket.Object(object_key)
-    response = obj.get()['Body']
+    response = obj.get()["Body"]
     if object_key.endswith(".gz"):
         stream = io.BytesIO(response.read())
         lines = gzip.GzipFile(fileobj=stream).read().decode()

--- a/logging/log_processing/config.py
+++ b/logging/log_processing/config.py
@@ -3,9 +3,9 @@ Access to shared settings and managing indices
 """
 
 import argparse
+import datetime
 import sys
 import time
-import datetime
 
 import boto3
 import elasticsearch
@@ -35,7 +35,7 @@ def log_index(date=None):
 
 def set_es_endpoint(env_type, bucket_name, endpoint):
     """Set SSM parameters so that lambdas can find the appropriate Elasticsearch cluster."""
-    client = boto3.client('ssm')
+    client = boto3.client("ssm")
     for parameter in (ES_ENDPOINT_BY_ENV_TYPE, ES_ENDPOINT_BY_BUCKET):
         name = parameter.format(env_type=env_type, bucket_name=bucket_name)
         print("Setting parameter '{}'".format(name))
@@ -44,17 +44,10 @@ def set_es_endpoint(env_type, bucket_name, endpoint):
             Description="Value of 'host:port' of Elasticsearch cluster for log processing",
             Value=endpoint,
             Type="String",
-            Overwrite=True
+            Overwrite=True,
         )
         client.add_tags_to_resource(
-            ResourceType="Parameter",
-            ResourceId=name,
-            Tags=[
-                {
-                    "Key": "user:project",
-                    "Value": "data-warehouse"
-                }
-            ]
+            ResourceType="Parameter", ResourceId=name, Tags=[{"Key": "user:project", "Value": "data-warehouse"}]
         )
 
 
@@ -66,22 +59,25 @@ def get_es_endpoint(env_type=None, bucket_name=None):
         name = ES_ENDPOINT_BY_BUCKET.format(bucket_name=bucket_name)
     else:
         raise ValueError("one of 'env_type' or 'bucket_name' must be not None")
-    client = boto3.client('ssm')
+    client = boto3.client("ssm")
     print("Looking up parameter '{}'".format(name))
     response = client.get_parameter(Name=name, WithDecryption=False)
     es_endpoint = response["Parameter"]["Value"]
-    host, port = es_endpoint.rsplit(':', 1)
+    host, port = es_endpoint.rsplit(":", 1)
     return host, int(port)
 
 
 def _aws_auth():
     # https://github.com/sam-washington/requests-aws4auth/pull/2
     session = boto3.Session()
-    print("Retrieving credentials (profile_name={}, region_name={})".format(session.profile_name, session.region_name),
-          file=sys.stderr)
+    print(
+        "Retrieving credentials (profile_name={}, region_name={})".format(session.profile_name, session.region_name),
+        file=sys.stderr,
+    )
     credentials = session.get_credentials()
-    aws4auth = requests_aws4auth.AWS4Auth(credentials.access_key, credentials.secret_key, session.region_name, "es",
-                                          session_token=credentials.token)
+    aws4auth = requests_aws4auth.AWS4Auth(
+        credentials.access_key, credentials.secret_key, session.region_name, "es", session_token=credentials.token
+    )
 
     def wrapped_aws4auth(request):
         return aws4auth(request)
@@ -103,7 +99,7 @@ def connect_to_es(host, port, use_auth=False):
         verify_certs=True,
         connection_class=elasticsearch.connection.RequestsHttpConnection,
         http_auth=http_auth,
-        send_get_body_as="POST"
+        send_get_body_as="POST",
     )
     return es
 
@@ -117,13 +113,8 @@ def put_index_template(client):
     body = {
         "template": LOG_INDEX_PATTERN,
         "version": version,
-        "settings": {
-            "number_of_shards": 2,
-            "number_of_replicas": 1
-        },
-        "mappings": {
-            "properties": parse.LogRecord.index_properties()
-        }
+        "settings": {"number_of_shards": 2, "number_of_replicas": 1},
+        "mappings": {"properties": parse.LogRecord.index_properties()},
     }
     print("Updating index template '{}' (version={})".format(LOG_INDEX_TEMPLATE_NAME, version))
     client.indices.put_template(LOG_INDEX_TEMPLATE_NAME, body)
@@ -208,10 +199,10 @@ def sub_delete_stale_indices(args):
     try:
         proceed = input("Proceed to delete old indices? (y/[n]) ")
     except EOFError:
-        proceed = 'n'
-    if proceed.lower() in ('y', 'yes'):
+        proceed = "n"
+    if proceed.lower() in ("y", "yes"):
         print("Ok, deleting old indices.")
-        es.indices.delete(','.join(sorted(stale)))
+        es.indices.delete(",".join(sorted(stale)))
 
 
 def main():

--- a/logging/log_processing/template.py
+++ b/logging/log_processing/template.py
@@ -1,23 +1,16 @@
 LOG_RECORD_PROPERTIES = {
     "application_name": {"type": "keyword"},
     "environment": {"type": "keyword"},
-    "logfile": {
-        "type": "keyword",
-    },
+    "logfile": {"type": "keyword"},
     "data_pipeline": {
         "properties": {
             "id": {"type": "keyword"},
             "component": {"type": "keyword"},
             "instance": {"type": "keyword"},
-            "attempt": {"type": "keyword"}
+            "attempt": {"type": "keyword"},
         }
     },
-    "emr_cluster": {
-        "properties": {
-            "id": {"type": "keyword"},
-            "step_id": {"type": "keyword"}
-        }
-    },
+    "emr_cluster": {"properties": {"id": {"type": "keyword"}, "step_id": {"type": "keyword"}}},
     "@timestamp": {"type": "date", "format": "strict_date_optional_time"},  # generic ISO datetime parser
     "datetime": {
         "properties": {
@@ -29,39 +22,18 @@ LOG_RECORD_PROPERTIES = {
             "day_of_week": {"type": "integer"},
             "hour": {"type": "integer"},
             "minute": {"type": "integer"},
-            "second": {"type": "integer"}
+            "second": {"type": "integer"},
         },
     },
     "etl_id": {"type": "keyword"},
     "log_level": {"type": "keyword"},
-    "logger": {
-        "type": "text",
-        "analyzer": "simple",
-        "fields": {
-            "name": {
-                "type": "keyword"
-            }
-        }
-    },
+    "logger": {"type": "text", "analyzer": "simple", "fields": {"name": {"type": "keyword"}}},
     "thread_name": {"type": "keyword"},
-    "source_code": {
-        "properties": {
-            "filename": {"type": "text"},
-            "line_number": {"type": "integer"},
-        }
-    },
+    "source_code": {"properties": {"filename": {"type": "text"}, "line_number": {"type": "integer"}}},
     "message": {
         "type": "text",
         "analyzer": "standard",
-        "fields": {
-            "raw": {
-                "type": "keyword"
-            },
-            "english": {
-                "type": "text",
-                "analyzer": "english"
-            }
-        }
+        "fields": {"raw": {"type": "keyword"}, "english": {"type": "text", "analyzer": "english"}},
     },
     "monitor": {
         "properties": {
@@ -71,25 +43,13 @@ LOG_RECORD_PROPERTIES = {
             "target": {"type": "keyword"},
             "elapsed": {"type": "float"},
             "rowcount": {"type": "long"},
-            "error_codes": {"type": "text"}
+            "error_codes": {"type": "text"},
         }
     },
-    "parser": {
-        "properties": {
-            "start_pos": {"type": "long"},
-            "end_pos": {"type": "long"},
-            "chars": {"type": "long"}
-        },
-    },
+    "parser": {"properties": {"start_pos": {"type": "long"}, "end_pos": {"type": "long"}, "chars": {"type": "long"}}},
     # These last properties are only used by the Lambda handler:
     "lambda_name": {"type": "keyword"},
     "lambda_version": {"type": "keyword"},
-    "context": {
-        "properties": {
-            "remaining_time_in_millis": {"type": "long"}
-        }
-    },
-    "original_logfile": {
-        "type": "keyword",
-    }
+    "context": {"properties": {"remaining_time_in_millis": {"type": "long"}}},
+    "original_logfile": {"type": "keyword"},
 }

--- a/logging/log_processing/upload.py
+++ b/logging/log_processing/upload.py
@@ -36,12 +36,10 @@ def _build_meta_doc(context, event_data):
     doc = {
         "lambda_name": context.function_name,
         "lambda_version": context.function_version,
-        "logfile": '/'.join((context.log_group_name, context.log_stream_name)),
+        "logfile": "/".join((context.log_group_name, context.log_stream_name)),
         "log_level": "INFO",
-        "@timestamp": event_data['eventTime'],
-        "context": {
-            "remaining_time_in_millis": context.get_remaining_time_in_millis()
-        }
+        "@timestamp": event_data["eventTime"],
+        "context": {"remaining_time_in_millis": context.get_remaining_time_in_millis()},
     }
     return doc
 
@@ -79,11 +77,14 @@ def lambda_handler(event, context):
         ]
     }
     """
-    for i, event_data in enumerate(event['Records']):
-        bucket_name = event_data['s3']['bucket']['name']
-        object_key = urllib.parse.unquote_plus(event_data['s3']['object']['key'])
-        print("Event #{:d}: source={}, event={}, time={}, bucket={}, key={}".format(
-            i, event_data['eventSource'], event_data['eventName'], event_data['eventTime'], bucket_name, object_key))
+    for i, event_data in enumerate(event["Records"]):
+        bucket_name = event_data["s3"]["bucket"]["name"]
+        object_key = urllib.parse.unquote_plus(event_data["s3"]["object"]["key"])
+        print(
+            "Event #{:d}: source={}, event={}, time={}, bucket={}, key={}".format(
+                i, event_data["eventSource"], event_data["eventName"], event_data["eventTime"], bucket_name, object_key
+            )
+        )
 
         if not (object_key.startswith("_logs/") or "/logs/" in object_key):
             print("Path is not in log folder ... skipping this file")
@@ -101,7 +102,7 @@ def lambda_handler(event, context):
             print("Failed to find records in object '{}'".format(file_uri))
             return
         except botocore.exceptions.ClientError as exc:
-            error_code = exc.response['Error']['Code']
+            error_code = exc.response["Error"]["Code"]
             print("Error code {} for object '{}'".format(error_code, file_uri))
             return
 
@@ -113,7 +114,7 @@ def lambda_handler(event, context):
         sha1_hash.update(file_uri.encode())
         id_ = sha1_hash.hexdigest()
         res = es.index(index=config.log_index(), body=body, id=id_)
-        print("Sent meta information, result: {}, index: {}".format(res['result'], res['_index']))
+        print("Sent meta information, result: {}, index: {}".format(res["result"], res["_index"]))
         print("Time remaining (ms):", context.get_remaining_time_in_millis())
 
 


### PR DESCRIPTION
This PR uses the config from: Add config for code formatter and linter #15
to run `black` and `isort` on the `logging/log_processing` code.

There were 4 pep8 violations around lack of whitespace after `,` which I fixed manually. This code now stays unchanged when re-running `black` and `isort` and is compatible with `pycodestyle`