### PR TITLE
Bug fixes: logging field name and cloudformation search path

### DIFF
--- a/bin/do_cloudformation.sh
+++ b/bin/do_cloudformation.sh
@@ -33,7 +33,7 @@ echo "Trying to \"$CF_VERB\" a \"$CF_OBJECT\" within stack \"$STACK_NAME\"..."
 
 BINDIR=`dirname $0`
 FOUND=no
-TEMPLATE_DIRS=". ./cloudformation $BINDIR"
+TEMPLATE_DIRS=". ./cloudformation ../cloudformation $BINDIR"
 for TEMP_DIR in $TEMPLATE_DIRS; do
     TEMPLATE_FILE="$TEMP_DIR/$CF_OBJECT.yaml"
     if [[ -r "$TEMPLATE_FILE" ]]; then

--- a/logging/log_processing/json_logging.py
+++ b/logging/log_processing/json_logging.py
@@ -65,7 +65,7 @@ class JsonFormatter(logging.Formatter):
 
     attribute_mapping = {
         # LogRecord attributes for which we want new names:
-        "filename": "source:filename",
+        "filename": "source.filename",
         "funcName": "source.function",
         "levelname": "log_level",
         "levelno": "log_severity",


### PR DESCRIPTION
Bugs fixed:
* Logging of the filename accidentally went to `source:filename` instead of `source.filename`.
* The search path missed the parent directory (PR #11)