### PR TITLE
Reduce line length to 100

### DIFF
--- a/logging/log_processing/config.py
+++ b/logging/log_processing/config.py
@@ -58,7 +58,11 @@ def set_es_endpoint(env_type, bucket_name, endpoint):
 
 
 def get_es_endpoint(env_type=None, bucket_name=None):
-    """Get value of SSM parameters based either on the environment or the bucket (which has presumably log files)."""
+    """
+    Get value of SSM parameters based either on the environment or the bucket.
+
+    (The bucket should presumably have log files).
+    """
     if env_type is not None:
         name = ES_ENDPOINT_BY_ENV_TYPE.format(env_type=env_type)
     elif bucket_name is not None:
@@ -77,7 +81,8 @@ def _aws_auth():
     # https://github.com/sam-washington/requests-aws4auth/pull/2
     session = boto3.Session()
     logger.info(
-        f"Retrieving credentials (profile_name={session.profile_name}, region_name={session.region_name})",
+        f"Retrieving credentials "
+        "(profile_name={session.profile_name}, region_name={session.region_name})",
     )
     credentials = session.get_credentials()
     aws4auth = requests_aws4auth.AWS4Auth(
@@ -96,7 +101,9 @@ def _aws_auth():
 
 def connect_to_es(host, port, use_auth=False):
     """
-    Return client. Unless running from authorized IP, set use_auth to True so that credentials are based on role.
+    Return client that's connected to an Elasticsearch cluster.
+
+    Unless running from authorized IP, set use_auth to True so that credentials are based on role.
     """
     if use_auth:
         http_auth = _aws_auth()

--- a/logging/log_processing/config.py
+++ b/logging/log_processing/config.py
@@ -51,7 +51,9 @@ def set_es_endpoint(env_type, bucket_name, endpoint):
             Overwrite=True,
         )
         client.add_tags_to_resource(
-            ResourceType="Parameter", ResourceId=name, Tags=[{"Key": "user:project", "Value": "data-warehouse"}]
+            ResourceType="Parameter",
+            ResourceId=name,
+            Tags=[{"Key": "user:project", "Value": "data-warehouse"}],
         )
 
 
@@ -74,10 +76,16 @@ def get_es_endpoint(env_type=None, bucket_name=None):
 def _aws_auth():
     # https://github.com/sam-washington/requests-aws4auth/pull/2
     session = boto3.Session()
-    logger.info(f"Retrieving credentials (profile_name={session.profile_name}, region_name={session.region_name})",)
+    logger.info(
+        f"Retrieving credentials (profile_name={session.profile_name}, region_name={session.region_name})",
+    )
     credentials = session.get_credentials()
     aws4auth = requests_aws4auth.AWS4Auth(
-        credentials.access_key, credentials.secret_key, session.region_name, "es", session_token=credentials.token
+        credentials.access_key,
+        credentials.secret_key,
+        session.region_name,
+        "es",
+        session_token=credentials.token,
     )
 
     def wrapped_aws4auth(request):
@@ -131,7 +139,10 @@ def get_current_indices(client):
 def get_allowable_indices():
     """Return set of indices expected in use given our retention period."""
     today = datetime.datetime.utcnow()
-    return frozenset(get_index_name(today - datetime.timedelta(days=days)) for days in range(0, OLDEST_INDEX_IN_DAYS))
+    return frozenset(
+        get_index_name(today - datetime.timedelta(days=days))
+        for days in range(0, OLDEST_INDEX_IN_DAYS)
+    )
 
 
 def build_parser():
@@ -143,22 +154,34 @@ def build_parser():
     get_config_parser.add_argument("env_type", help="environment type (like 'dev' or 'prod')")
     get_config_parser.set_defaults(func=sub_get_endpoint)
     # Set new configuration
-    set_config_parser = subparsers.add_parser("set_endpoint", help="set endpoint for env type and bucket")
+    set_config_parser = subparsers.add_parser(
+        "set_endpoint", help="set endpoint for env type and bucket"
+    )
     set_config_parser.add_argument("env_type", help="environment type (like 'dev' or 'prod')")
     set_config_parser.add_argument("bucket_name", help="name of S3 bucket with log files")
-    set_config_parser.add_argument("endpoint", help="endpoint for Elasticsearch service (host:port)")
+    set_config_parser.add_argument(
+        "endpoint", help="endpoint for Elasticsearch service (host:port)"
+    )
     set_config_parser.set_defaults(func=sub_set_endpoint)
     # Upload (new) index template
-    put_index_template_parser = subparsers.add_parser("put_index_template", help="upload (new) index template")
-    put_index_template_parser.add_argument("env_type", help="environment type (like 'dev' or 'prod')")
+    put_index_template_parser = subparsers.add_parser(
+        "put_index_template", help="upload (new) index template"
+    )
+    put_index_template_parser.add_argument(
+        "env_type", help="environment type (like 'dev' or 'prod')"
+    )
     put_index_template_parser.set_defaults(func=sub_put_index_template)
     # Get list of current indices matching our pattern
     get_indices_parser = subparsers.add_parser("get_indices", help="get current indices")
     get_indices_parser.add_argument("env_type", help="environment type (like 'dev' or 'prod')")
     get_indices_parser.set_defaults(func=sub_get_indices)
     # Delete indices for records older than a year
-    delete_stale_indices_parser = subparsers.add_parser("delete_stale_indices", help="delete older indices")
-    delete_stale_indices_parser.add_argument("env_type", help="environment type (like 'dev' or 'prod')")
+    delete_stale_indices_parser = subparsers.add_parser(
+        "delete_stale_indices", help="delete older indices"
+    )
+    delete_stale_indices_parser.add_argument(
+        "env_type", help="environment type (like 'dev' or 'prod')"
+    )
     delete_stale_indices_parser.set_defaults(func=sub_delete_stale_indices)
     return parser
 

--- a/logging/log_processing/json_logging.py
+++ b/logging/log_processing/json_logging.py
@@ -58,7 +58,8 @@ class JsonFormatter(logging.Formatter):
         * The timestamps are in UTC.
     """
 
-    # This format is compatible with "strict_date_time" in Elasticsearch (yyyy-MM-dd'T'HH:mm:ss.SSSZZ).
+    # This format is compatible with "strict_date_time" in Elasticsearch:
+    # yyyy-MM-dd'T'HH:mm:ss.SSSZZ
     converter = time.gmtime
     default_time_format = "%Y-%m-%dT%H:%M:%SZ"
     default_msec_format = "%.19s.%03dZ"
@@ -101,14 +102,16 @@ class JsonFormatter(logging.Formatter):
                     data[new_name] = value
             else:
                 data[attr] = value
-        # The "message" is added last so an accidentally specified message in the extra kwargs is ignored.
+        # The "message" is added last so an accidentally specified message in the extra kwargs is
+        # ignored.
         data["message"] = record.getMessage()
         # Finally, always add a timestamp.
         data["gmtime"] = self.formatTime(record)
         return json.dumps(data, separators=(",", ":"), sort_keys=True)
 
 
-# We don't create the config dict until here so that we can use the classes (instead of class names in strings).
+# We don't create the config dict until here so that we can use the classes
+# (instead of class names in strings).
 LOGGING_STREAM_CONFIG = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/logging/log_processing/json_logging.py
+++ b/logging/log_processing/json_logging.py
@@ -124,7 +124,14 @@ LOGGING_STREAM_CONFIG = {
         }
     },
     "root": {"level": "INFO", "handlers": ["console"]},
-    "loggers": {"botocore": {"qualname": "botocore", "handlers": ["console"], "level": "WARNING", "propagate": 0}},
+    "loggers": {
+        "botocore": {
+            "qualname": "botocore",
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": 0,
+        }
+    },
 }
 
 

--- a/logging/log_processing/parse.py
+++ b/logging/log_processing/parse.py
@@ -70,7 +70,7 @@ class LogRecord(collections.UserDict):
             "end_pos": match.end(),
             "chars": match.end() - match.start(),
         }
-        # --- Timestamp (with pseudo-microseconds so that log lines stay sorted in order of logfile) ---
+        # Timestamp (with pseudo-microseconds so that log lines stay sorted in order of logfile).
         ts = values["_timestamp"]
         self.__counter[ts] += 1
         if values["_milliseconds"] is None:
@@ -82,7 +82,7 @@ class LogRecord(collections.UserDict):
         )
         self.update(
             {
-                "@timestamp": timestamp.isoformat(),  # Python datetime drops milliseconds if value is 0.
+                "@timestamp": timestamp.isoformat(),  # Python datetime drops milliseconds if 0.
                 "datetime": {
                     "epoch_time_in_millis": calendar.timegm(timestamp.timetuple()) * 1000
                     + timestamp.microsecond // 1000,
@@ -97,7 +97,7 @@ class LogRecord(collections.UserDict):
                 },
             }
         )
-        # --- Monitor payload ---
+        # Monitor payload
         if values["message"].startswith("Monitor payload = "):
             payload_text = values["message"].replace("Monitor payload = ", "", 1)
             try:
@@ -145,7 +145,7 @@ class LogParser:
 
     # Basic Regex to split up Arthur log lines
     _LOG_LINE_REGEX = r"""
-        # Look for timestamp from beginning of line, e.g. 2017-06-09 06:16:19,350 (where msecs are optional)
+        # Look for timestamp at beginning of line, e.g. 2017-06-09 06:16:19,350, with msecs optional
         ^(?P<_timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}(?:,(?P<_milliseconds>\d{3}))?)\s
         # Look for ETL id, e.g. CD58E5D3C73E4D45
         (?P<etl_id>[0-9A-Z]{16})\s

--- a/logging/log_processing/parse.py
+++ b/logging/log_processing/parse.py
@@ -203,7 +203,7 @@ class LogParser:
         '<prefix>/4'
         >>> lp.shared_info["data_pipeline"]["id"]
         'df-<id>'
-        """  # noqa Allow long lines for the examples
+        """  # noqa:E501 Allow long lines for the examples
         parts = self.shared_info["logfile"].replace("s3://", "", 1).split("/")
         if len(parts) >= 8:
             if parts[1] == "_logs":
@@ -258,7 +258,7 @@ class LogParser:
         '<prefix>/4'
         >>> lp.shared_info["emr_cluster"]["id"]
         'j-<id>'
-        """  # noqa Allow long lines for the examples
+        """  # noqa:E501 Allow long lines for the examples
         parts = self.shared_info["logfile"].replace("s3://", "", 1).split("/")
         if len(parts) >= 7 and parts[-3] == "steps":
             long_form = len(parts) >= 11 and parts[-4] == "hadoop"
@@ -323,7 +323,7 @@ def create_example_records():
         2016-06-26 07:52:45,106 EXAMPLE105754649 INFO etl.config (MainThread) [hello.py:89] Starting log ...
         2016-06-26 07:52:59 EXAMPLE105754649 ERROR etl.config (MainThread) [world.py:90] Trouble without millis...
         2016-06-26 07:53:02,107 EXAMPLE105754649 DEBUG etl.monitor (MainThread) [monitor.py:255] Monitor payload = {}
-    """  # noqa Leave long log lines on one line
+    """  # noqa:E501 Leave long log lines on one line
 
     # The examples are "old" enough for the corresponding index to be "stale".
     # (Use delete_stale_indices to get rid of the examples after uploading them to an ES cluster.)

--- a/logging/log_processing/parse.py
+++ b/logging/log_processing/parse.py
@@ -178,7 +178,7 @@ class LogParser:
 
     def extract_data_pipeline_information(self):
         """
-        Return information related to a data pipeline if it is contained in the filename of the logfile.
+        Extract information related to a data pipeline from the filename of the logfile.
 
         The examples below have "<prefix>/{number}" as an environment to make them easier to distinguish.
         >>> lp = LogParser("s3://<bucket>/_logs/<prefix>/1/df-<id>/<component>/<instance>/<attempt>/<cluster_id>/"
@@ -203,7 +203,7 @@ class LogParser:
         '<prefix>/4'
         >>> lp.shared_info["data_pipeline"]["id"]
         'df-<id>'
-        """
+        """  # noqa Allow long lines for the examples
         parts = self.shared_info["logfile"].replace("s3://", "", 1).split("/")
         if len(parts) >= 8:
             if parts[1] == "_logs":
@@ -231,7 +231,7 @@ class LogParser:
 
     def extract_emr_cluster_information(self):
         """
-        Return information related to an EMR cluster if it is contained in the filename of the logfile.
+        Extract information related to an EMR cluster from the filename of the logfile.
 
         Basically extract from:
         >>> lp = LogParser("s3://<bucket>/_logs/<prefix>/1/j-<id>/node/<node_id>/applications/hadoop/"
@@ -258,7 +258,7 @@ class LogParser:
         '<prefix>/4'
         >>> lp.shared_info["emr_cluster"]["id"]
         'j-<id>'
-        """
+        """  # noqa Allow long lines for the examples
         parts = self.shared_info["logfile"].replace("s3://", "", 1).split("/")
         if len(parts) >= 7 and parts[-3] == "steps":
             long_form = len(parts) >= 11 and parts[-4] == "hadoop"
@@ -319,14 +319,15 @@ def create_example_records():
         "target": "schema.example",
         "elapsed": 21.117434,
     }
-    # The examples are "old" enough for the corresponding index to be "stale" ... see delete_stale_indices
-    examples = """
+    log_lines = """
         2016-06-26 07:52:45,106 EXAMPLE105754649 INFO etl.config (MainThread) [hello.py:89] Starting log ...
         2016-06-26 07:52:59 EXAMPLE105754649 ERROR etl.config (MainThread) [world.py:90] Trouble without millis...
         2016-06-26 07:53:02,107 EXAMPLE105754649 DEBUG etl.monitor (MainThread) [monitor.py:255] Monitor payload = {}
-    """.format(
-        json.dumps(monitor)
-    )
+    """  # noqa Leave long log lines on one line
+
+    # The examples are "old" enough for the corresponding index to be "stale".
+    # (Use delete_stale_indices to get rid of the examples after uploading them to an ES cluster.)
+    examples = log_lines.format(json.dumps(monitor))
     lines = textwrap.dedent(examples)
     parser = LogParser("examples")
     return list(parser.split_log_lines(lines))

--- a/logging/log_processing/parse.py
+++ b/logging/log_processing/parse.py
@@ -57,9 +57,19 @@ class LogRecord(collections.UserDict):
         values = match.groupdict()
         # --- Basic info ---
         self.message = values["message"]
-        self.update({k: v for k, v in values.items() if k in ["etl_id", "log_level", "logger", "thread_name"]})
+        self.update(
+            {
+                k: v
+                for k, v in values.items()
+                if k in ["etl_id", "log_level", "logger", "thread_name"]
+            }
+        )
         self["source_code"] = {k: v for k, v in values.items() if k in ["filename", "line_number"]}
-        self["parser"] = {"start_pos": match.start(), "end_pos": match.end(), "chars": match.end() - match.start()}
+        self["parser"] = {
+            "start_pos": match.start(),
+            "end_pos": match.end(),
+            "chars": match.end() - match.start(),
+        }
         # --- Timestamp (with pseudo-microseconds so that log lines stay sorted in order of logfile) ---
         ts = values["_timestamp"]
         self.__counter[ts] += 1
@@ -67,7 +77,9 @@ class LogRecord(collections.UserDict):
             ts += ",{:06d}".format(self.__counter[ts])  # 04:05:06 -> 04:05:06,000001
         else:
             ts += "{:03d}".format(self.__counter[ts])  # 04:05:06,789 -> 04:05:06,789001
-        timestamp = datetime.datetime.strptime(ts, "%Y-%m-%d %H:%M:%S,%f").replace(tzinfo=datetime.timezone.utc)
+        timestamp = datetime.datetime.strptime(ts, "%Y-%m-%d %H:%M:%S,%f").replace(
+            tzinfo=datetime.timezone.utc
+        )
         self.update(
             {
                 "@timestamp": timestamp.isoformat(),  # Python datetime drops milliseconds if value is 0.
@@ -99,7 +111,9 @@ class LogRecord(collections.UserDict):
                     if k in ["monitor_id", "step", "event", "target", "elapsed"]
                 }
                 if "errors" in monitor_payload:
-                    self["monitor"]["error_codes"] = " ".join(error["code"] for error in monitor_payload["errors"])
+                    self["monitor"]["error_codes"] = " ".join(
+                        error["code"] for error in monitor_payload["errors"]
+                    )
                 if "extra" in monitor_payload and "rowcount" in monitor_payload["extra"]:
                     self["monitor"]["rowcount"] = monitor_payload["extra"]["rowcount"]
 
@@ -209,7 +223,10 @@ class LogParser:
                 environment = None
                 data_pipeline = None
             if environment is not None and data_pipeline[0].startswith("df-"):
-                return environment, dict(zip(["id", "component", "instance", "attempt"], data_pipeline))
+                return (
+                    environment,
+                    dict(zip(["id", "component", "instance", "attempt"], data_pipeline)),
+                )
         return None, {}
 
     def extract_emr_cluster_information(self):

--- a/logging/log_processing/template.py
+++ b/logging/log_processing/template.py
@@ -11,7 +11,10 @@ LOG_RECORD_PROPERTIES = {
         }
     },
     "emr_cluster": {"properties": {"id": {"type": "keyword"}, "step_id": {"type": "keyword"}}},
-    "@timestamp": {"type": "date", "format": "strict_date_optional_time"},  # generic ISO datetime parser
+    "@timestamp": {
+        "type": "date",
+        "format": "strict_date_optional_time",
+    },  # generic ISO datetime parser
     "datetime": {
         "properties": {
             "epoch_time_in_millis": {"type": "long"},
@@ -29,7 +32,9 @@ LOG_RECORD_PROPERTIES = {
     "log_level": {"type": "keyword"},
     "logger": {"type": "text", "analyzer": "simple", "fields": {"name": {"type": "keyword"}}},
     "thread_name": {"type": "keyword"},
-    "source_code": {"properties": {"filename": {"type": "text"}, "line_number": {"type": "integer"}}},
+    "source_code": {
+        "properties": {"filename": {"type": "text"}, "line_number": {"type": "integer"}}
+    },
     "message": {
         "type": "text",
         "analyzer": "standard",
@@ -46,5 +51,11 @@ LOG_RECORD_PROPERTIES = {
             "error_codes": {"type": "text"},
         }
     },
-    "parser": {"properties": {"start_pos": {"type": "long"}, "end_pos": {"type": "long"}, "chars": {"type": "long"}}},
+    "parser": {
+        "properties": {
+            "start_pos": {"type": "long"},
+            "end_pos": {"type": "long"},
+            "chars": {"type": "long"},
+        }
+    },
 }

--- a/logging/log_processing/upload.py
+++ b/logging/log_processing/upload.py
@@ -18,7 +18,7 @@ import elasticsearch.helpers
 
 from log_processing import compile, config, json_logging, parse
 
-# This is done during module initialization so that it is done once for a Lambda runtime environment.
+# This is done during module initialization so that it is done once for the Lambda runtime.
 json_logging.configure_logging()
 logger = json_logging.getLogger(__name__)
 

--- a/logging/log_processing/upload.py
+++ b/logging/log_processing/upload.py
@@ -37,7 +37,9 @@ def index_records(es, records_generator):
     """
     Bulk-index log records. The appropriate index is chosen given the date of the log record.
     """
-    for date, records in itertools.groupby(records_generator, key=lambda rec: rec["datetime"]["date"]):
+    for date, records in itertools.groupby(
+        records_generator, key=lambda rec: rec["datetime"]["date"]
+    ):
         index = config.get_index_name(date)
         n_errors = 0
         n_ok, errors = elasticsearch.helpers.bulk(es, _build_actions_from(index, records))
@@ -74,7 +76,9 @@ def lambda_handler(event, context):
     )
     for i, event_data in enumerate(event["Records"]):
         logger.info(
-            "Event #{i}: source={eventSource}, name={eventName}, time={eventTime}".format(i=i, **event_data),
+            "Event #{i}: source={eventSource}, name={eventName}, time={eventTime}".format(
+                i=i, **event_data
+            ),
             extra={
                 "event.source": event_data["eventSource"],
                 "event.name": event_data["eventName"],

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -1,6 +1,5 @@
 from setuptools import find_packages, setup
 
-
 setup(
     name="log_processing",
     version="1.5.0",
@@ -13,7 +12,7 @@ setup(
             "show_log_examples = log_processing.parse:main",
             "search_log = log_processing.compile:main",
             "config_log = log_processing.config:main",
-            "upload_log = log_processing.upload:main"
+            "upload_log = log_processing.upload:main",
         ]
-    }
+    },
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 include = '\.pyi?$'
-line-length = 120
+line-length = 100
 target-version = ['py36']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [pycodestyle]
 # Seetings are compatible with black, see https://github.com/psf/black/issues/354
-ignore = E203,W503
-# This is the current setting for this project. We may want to think to drop to 88.
-max-line-length = 120
+ignore = E203, W503
+max-line-length = 100


### PR DESCRIPTION
This PR is both a suggestion and a test of the outcome. I've reduced the line-length configured for `black` and `pycodestyle`. I used to favor **120** characters because that's the max which still allows reading code in GitHub. I've learned that it's better to aim for a smaller line length, _e.g._ **100** in order to make PR reviews easier where we'd still like to see the whole line in diffs.

The commits show that we can mostly rely on `black` to re-format code. But note that some long strings (including doc strings) and comments aren't broken by `black` so that requires manual intervention to become `pycodestyle` compliant. Of course, this is just true because this is "old" code. For new code, we'd get the line lengths right from the beginning.

The commits here also show what to do when we do want or need to keep long lines: add `# noqa:E501` at the end of the line. (If there's a triple-quoted string, add at the end of the string, not each line.)