### PR TITLE
Add sticky fields to log records

### DIFF
--- a/logging/log_processing/config.py
+++ b/logging/log_processing/config.py
@@ -5,7 +5,6 @@ Access to shared settings and managing indices
 import argparse
 import datetime
 import logging
-import sys
 import time
 from functools import lru_cache
 

--- a/logging/log_processing/json_logging.py
+++ b/logging/log_processing/json_logging.py
@@ -139,7 +139,7 @@ LOGGING_STREAM_CONFIG = {
             "handlers": ["console"],
             "level": "WARNING",
             "propagate": 0,
-        }
+        },
     },
 }
 

--- a/logging/log_processing/json_logging.py
+++ b/logging/log_processing/json_logging.py
@@ -133,6 +133,12 @@ LOGGING_STREAM_CONFIG = {
             "handlers": ["console"],
             "level": "WARNING",
             "propagate": 0,
+        },
+        "elasticsearch": {
+            "qualname": "elasticsearch",
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": 0,
         }
     },
 }


### PR DESCRIPTION
This demonstrates using the `logging.LoggerAdapter` class to keep some `extra` information around. In this case, I'm adding an `event_id` to make it easier to tie log records corresponding to a specific event (from the list of events in the Lambda). Example output:
```
{
    "aws_request_id": "12345678-5b26-1234-9ef3-12345678",
    "cwl.log_stream_name": "2020/03/11/[$LATEST]abcdefabcdef",
    "event_id": "12345678-5b26-1234-9ef3-12345678.0",
    "gmtime": "2020-03-11T03:37:20.771Z",
    "lambda.function_name": "dw-es-domain-dev-LogParsingLambdaFunction-SBCDEAFG",
    "lambda.function_version": "$LATEST",
    "log_level": "INFO",
    "log_severity": 20,
    "logger": "log_processing.upload",
    "message": "Processing event: index=0, source=aws:s3, name=ObjectCreated:Put, time=2020-03-11T03:37:18.928408",
    "process.id": 1,
    "process.name": "MainProcess",
    "source.filename": "upload.py",
    "source.function": "lambda_handler",
    "source.line_number": 94,
    "source.module": "upload",
    "source.pathname": "/var/task/log_processing/upload.py",
    "thread.name": "MainThread"
}
```

This also changes the min log level to warning for the `elasticsearch` logger.