### PR TITLE
Initial version of json_logging

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,16 +6,16 @@ end_of_line = lf
 insert_final_newline = true
 max_line_length = 100
 
-[*.{py,sh}]
-indent_size = 4
-indent_style = space
-tab_width = 4
-trim_trailing_whitespace = true
-
 [*.md]
 indent_size = 4
 indent_style = space
 max_line_length = 80
+tab_width = 4
+trim_trailing_whitespace = true
+
+[*.{py,sh}]
+indent_size = 4
+indent_style = space
 tab_width = 4
 trim_trailing_whitespace = true
 

--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,6 @@ coverage.xml
 *.mo
 *.pot
 
-
 # Sphinx documentation
 docs/_build/
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,19 @@
 # Arthur Tools
 
 We have some tools that we developed originally for [Project Arthur](https://github.com/harrystech/arthur-redshift-etl)
-which then appeared to more generally useful. So here they are.
+which then appeared to be more generally useful. So here they are.
+
+## JSON-formatted Logging
+
+The package `json_logging` supports regular Python logging to be formatted as JSON
+which makes it much easier to poss-process, for example, for example by loading
+log lines into an Elasticsearch cluster.
+
+See the [README](./json_logging/README.md) for more details about installatioon and usage.
+
+----
+
+# Older stuff that needs to be updated
 
 ## Deploying CloudFormation templates
 

--- a/json_logging/README.md
+++ b/json_logging/README.md
@@ -1,0 +1,90 @@
+# JSON-formatted Logging
+
+The package `json_logging` supports regular Python logging to be formatted as
+JSON which makes it much easier to poss-process, for example, by loading log
+lines into an Elasticsearch cluster.
+
+## Installation
+
+Add this line to your `requirements.txt` file:
+```text
+git+https://github.com/harrystech/arthur-tools.git#subdirectory=json_logging&egg=json-logging'
+```
+
+You can also test the installation by calling `pip` directly. (You should
+probably do so inside a Docker container or using a virtual environment.)
+```shell
+python3 -m venv venv
+source venv/bin/activate
+python3 -m pip install --upgrade 'git+https://github.com/harrystech/arthur-tools.git@add-json-logging-package#subdirectory=json_logging&egg=json-logging'
+```
+
+## Usage
+
+### General use in applications
+
+Add something like this to your code:
+```python
+import json_logging
+
+json_logging.configure_logging()
+logger = json_logging.getLogger(__name__)
+logger.info("Hello World!")
+```
+
+### Use for Lambda functions
+
+```python
+import json_logging
+
+json_logging.configure_logging()
+logger = json_logging.getLogger(__name__)
+
+
+def handle_event(event, context):
+    json_logging.update_context(
+        aws_request_id=context.aws_request_id,
+        function_name=context.function_name,
+        function_version=context.function_version,
+        log_stream_name=context.log_stream_name,
+    )
+    logger.info(f"Starting {__name__}", extra={"event": event})
+```
+
+### Additional info
+
+### "Extra" information
+
+You can send information into the log record using the `extra` kwarg, which
+avoids having to process the message later:
+```python
+logger.info(f"Finished processing {num_count} file(s)", extra={"file_count": num_count})
+```
+
+#### Context wrapper
+
+Log an exception along with a stracktrace like so:
+```python
+with json_logging.log_stack_trace(logger):
+    do_something_dangerous()
+```
+
+## Fields
+
+Name | Example value | Notes
+----|----|----
+`aws_request_id` | | Request id when executing a function in AWS
+`gmtime` | `2020-08-02T15:24:59.154Z` | Timestamp in RFC3339 format
+`log_level` | `INFO` | Log level as string
+`log_severity` | 20 | Log level as number
+`logger` | `mod.func` | Name of the logger, usually set using `__name__`
+`message` | `Doing work` | Log message
+`process.id` | 75478 | Id of the process running the application
+`process.name` | `MainProcess` | Name of the process running the application
+`source.filename` | `example.py` | File where we logged
+`source.function` | `do_something` | Name of the function within which we logged
+`source.line_number` | 42 | Where in the source file we logged
+`source.module` | `example` | Name of the module (which may be less unique than the filename)
+`source.pathname` | `python/src/example.py` | Location of the source file in the package
+`thread.name` | `MainThread` | Name of the thread
+`timestamp` | 1596381899154 | Epoch milliseconds

--- a/json_logging/json_logging/__init__.py
+++ b/json_logging/json_logging/__init__.py
@@ -1,0 +1,191 @@
+"""
+Enable logging (from Lambda functions) in JSON format which makes post-processing much easier.
+
+Since we assume this will be used by Lambda functions, we also add the request id in log lines.
+"""
+
+import json
+import logging
+import logging.config
+import time
+import traceback
+from contextlib import ContextDecorator
+
+
+class ContextFilter(logging.Filter):
+    """
+    Logging Filter class that adds contextual information to log records.
+
+    We assume there will be only one instance of this filter for any runtime which
+    means that we will store some values with the class, not the instances.
+    """
+
+    _context = {
+        "aws_request_id": "UNKNOWN",  # mypy stumbles on all values being None
+        "function_name": None,
+        "function_version": None,
+        "log_group_name": None,
+        "log_stream_name": None,
+    }
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Modify record in place for additional fields, then return True to continue processing."""
+        for field, value in self._context.items():
+            if value is not None:
+                setattr(record, field, value)
+        return True
+
+    @classmethod
+    def update_context(cls, **kwargs: str) -> None:
+        """
+        Update any of the fields stored in the (global) context filter.
+
+        Note that trying to set a field that's not been defined raises a ValueError.
+        """
+        for field, value in kwargs.items():
+            if field in cls._context:
+                cls._context[field] = value
+            else:
+                raise ValueError(f"unexpected field: '{field}'")
+
+
+class JsonFormatter(logging.Formatter):
+    """
+    Format the message to be easily reverted into an object by using JSON format.
+
+    Notes:
+        * The "format" is ignored since we convert based on available info.
+        * The timestamps are in UTC.
+    """
+
+    # This format is compatible with "strict_date_time" in Elasticsearch:
+    # yyyy-MM-dd'T'HH:mm:ss.SSSZZ
+    converter = time.gmtime
+    default_time_format = "%Y-%m-%dT%H:%M:%SZ"
+    default_msec_format = "%.19s.%03dZ"
+
+    attribute_mapping = {
+        # LogRecord attributes for which we want new names:
+        "filename": "source.filename",
+        "funcName": "source.function",
+        "levelname": "log_level",
+        "levelno": "log_severity",
+        "lineno": "source.line_number",
+        "module": "source.module",
+        "name": "logger",
+        "pathname": "source.pathname",
+        "process": "process.id",
+        "processName": "process.name",
+        "threadName": "thread.name",
+        # Common context attributes which we want to rename:
+        "function_name": "lambda.function_name",
+        "function_version": "lambda.function_version",
+        "log_stream_name": "cwl.log_stream_name",
+        # LogRecord attributes which we want to suppress:
+        "args": None,
+        "created": None,
+        "msecs": None,
+        "msg": None,
+        "relativeCreated": None,
+        "thread": None,
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format log record by creating a JSON-format in a string."""
+        data = {}
+        for attr, value in record.__dict__.items():
+            if value is None:
+                continue
+            if attr in self.attribute_mapping:
+                new_name = self.attribute_mapping[attr]
+                if new_name is not None:
+                    data[new_name] = value
+            else:
+                data[attr] = value
+        # The "message" is added last so an accidentally specified message in the extra kwargs
+        # is ignored.
+        data["message"] = record.getMessage()
+        # Finally, always add a timestamp as epoch msecs and in a human readable format.
+        # (Go to https://www.epochconverter.com/ to convert the timestamp in milliseconds.)
+        data["timestamp"] = int(record.created * 1000.0)
+        data["gmtime"] = self.formatTime(record)
+        return json.dumps(data, separators=(",", ":"), sort_keys=True)
+
+
+# We don't create the config dict until here so that we can use the classes
+# (instead of class names in strings).
+LOGGING_STREAM_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {"json_formatter": {"()": JsonFormatter}},
+    "filters": {"context_filter": {"()": ContextFilter}},
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+            "formatter": "json_formatter",
+            "filters": ["context_filter"],
+            "stream": "ext://sys.stdout",
+        }
+    },
+    "root": {"level": "INFO", "handlers": ["console"]},
+    "loggers": {
+        # Loggers from packages that we use and want to be less noisy:
+        "botocore": {
+            "qualname": "botocore",
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": 0,
+        },
+        "elasticsearch": {
+            "qualname": "elasticsearch",
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": 0,
+        },
+        "urllib3": {
+            "qualname": "urllib3",
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": 0,
+        },
+    },
+}
+
+
+def configure_logging() -> None:
+    logging.config.dictConfig(LOGGING_STREAM_CONFIG)
+
+
+# Just for developer convenience -- this avoids having too many imports of "logging" packages.
+def getLogger(name: str) -> logging.Logger:
+    return logging.getLogger(name)
+
+
+def update_context(**kwargs: str) -> None:
+    ContextFilter.update_context(**kwargs)
+
+
+class log_stack_trace(ContextDecorator):
+    """This context enables logging a stacktrace automatically when an exception occurs."""
+    
+    def __init__(self, logger: logging.Logger) -> None:
+        self._logger = logger
+
+    def __enter__(self) -> "log_stack_trace":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):  # type: ignore
+        if exc_type:
+            self._logger.error(
+                f"Exception: {exc_val!r}",
+                extra={"stack_trace": traceback.format_exception(exc_type, exc_val, exc_tb)},
+            )
+        return None
+
+
+if __name__ == "__main__":
+    configure_logging()
+    update_context(aws_request_id="62E538E9-E9C5-415A-9771-6588F9A1A708")
+
+    logging.info("Message at INFO level", extra={"planet": "earth"})

--- a/json_logging/setup.py
+++ b/json_logging/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    author="Harry's Data Engineering and Contributors",
+    description="Formatting of log lines using JSON-format",
+    license="MIT",
+    name="json_logging",
+    packages=["json_logging"],
+    python_requires=">=3.5",
+    url="https://github.com/harrystech/arthur-tools",
+    version="1.0.0",
+)


### PR DESCRIPTION
This adds a package so that we can easily share a logging setup across projects. Having the same logging configuration will make it easy to load log records into an Elasticsearch cluster or some other log collection.

Initial usage will be like this (in the `requirements.txt` file:
```
git+https://github.com/harrystech/arthur-tools.git#subdirectory=json_logging&egg=json-logging
```

We could also tag a version and then use:
```
git+https://github.com/harrystech/arthur-tools.git@jsong-logging=v1.0.0#subdirectory=json_logging&egg=json-logging
```

We can later play around with opening this package up using some pypi server, maybe a la https://www.freecodecamp.org/news/how-to-use-github-as-a-pypi-server-1c3b0d07db2/