### PR TITLE
Add linting in GitHub Action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,60 @@
+# Simple workflow to run linters.
+
+name: Lint Python code
+
+on:
+  push:
+    paths:
+    - ".github/workflows/lint.yaml"
+    - "cloudwatch_logs"
+    - "json_logging"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout out code
+      uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements-linters.txt') }}
+    - name: Install dependencies
+      run: |-
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --requirement requirements-linters.txt
+    - name: Lint with black
+      run: |-
+        black --check cloudwatch_logs/cw_logs_to_es json_logging
+    - name: Lint with isort
+      run: |-
+        isort --check-only cloudwatch_logs/cw_logs_to_es json_logging
+    - name: Lint with flake8
+      run: |-
+        flake8 cloudwatch_logs/cw_logs_to_es json_logging
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout out code
+      uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements-linters.txt') }}
+    - name: Install dependencies
+      run: |-
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --requirement requirements-linters.txt
+    - name: Run type checker
+      run: |-
+        mypy cloudwatch_logs/cw_logs_to_es json_logging

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -57,4 +57,4 @@ jobs:
         python3 -m pip install --requirement requirements-linters.txt
     - name: Run type checker
       run: |-
-        mypy cloudwatch_logs/cw_logs_to_es json_logging
+        mypy cloudwatch_logs/cw_logs_to_es json_logging || echo "This source code has issues."

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Until we have a setup with Docker, let's use a virtual environment.
 ```shell
 python3 -m venv venv
 source venv/bin/activate
-python3 -m pip install black isort mypy mypy-boto3 pycodestyle
+python3 -m pip install --upgrade --requirement requirements-linters.txt
 ```
 
 ### Usage
@@ -67,7 +67,7 @@ For example for `cloudwatch_logs`:
 source venv/bin/activate
 
 black cloudwatch_logs/cw_logs_to_es/
+flake8 cloudwatch_logs/cw_logs_to_es/
 isort cloudwatch_logs/cw_logs_to_es/
 mypy cloudwatch_logs/cw_logs_to_es/
-pycodestyle cloudwatch_logs/cw_logs_to_es/
 ```

--- a/cloudwatch_logs/cw_logs_to_es/cw_log_parser.py
+++ b/cloudwatch_logs/cw_logs_to_es/cw_log_parser.py
@@ -34,7 +34,7 @@ class CloudWatchLogsParser:
             source.update(event)
             try:
                 source.update(json.loads(msg_str))
-            except Exception as ex:
+            except Exception:
                 source.update(self.parse_dirty_json(msg_str))
 
             index_name = f"cw-{log_group_name}-{datetime.now(timezone.utc).strftime('%Y-%m-%d')}"

--- a/json_logging/json_logging/__init__.py
+++ b/json_logging/json_logging/__init__.py
@@ -168,7 +168,7 @@ def update_context(**kwargs: str) -> None:
 
 class log_stack_trace(ContextDecorator):
     """This context enables logging a stacktrace automatically when an exception occurs."""
-    
+
     def __init__(self, logger: logging.Logger) -> None:
         self._logger = logger
 

--- a/requirements-linters.txt
+++ b/requirements-linters.txt
@@ -1,0 +1,7 @@
+black==19.10b0
+flake8==3.8.3
+flake8-docstrings==1.5.0
+flake8-fixme==1.1.1
+isort==5.3.2
+mypy==0.782
+mypy-boto3==1.14.43

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,35 @@
-[pycodestyle]
-# Seetings are compatible with black, see https://github.com/psf/black/issues/354
-ignore = E203, W503
+[flake8]
+# Settings are compatible with black, see https://github.com/psf/black/issues/354
+ignore =
+    E203 # Whitespace before ':'
+    W503 # Line break occurred before a binary operator
+    D100 # Missing docstring in public module
+    D101 # Missing docstring in public class
+    D102 # Missing docstring in public method
+    D103 # Missing docstring in public function
+    D104 # Missing docstring in public package
+    D105 # Missing docstring in magic method
+    D106 # Missing docstring in public nested class
+    D107 # Missing docstring in __init__
+    T100 # fixme found (FIXME)
+    T101 # fixme found (TODO)
+
 max-line-length = 100
+max-complexity = 10
 
 [mypy]
 python_version = 3.8
+disallow_untyped_defs = True
 ignore_missing_imports = True
+strict_optional = True
+warn_redundant_casts = True
+warn_unreachable = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_unused_configs = True
+
+[pycodestyle]
+# Settings are compatible with black, see https://github.com/psf/black/issues/354
+ignore = E203,W503
+# This is the current setting for this project. We may want to drop this to 100.
+max-line-length = 100


### PR DESCRIPTION
This PR adds a GitHub Action to lint the code in this repo. To get started, this will only check the two projects `cloudwatch_logs` and `json_logging`. We can improve this as necessary.
Note that this switches from `pycodestyle` to `flake8`. (I've fixed a couple errors from `flake8` in this PR -- fixing all issues reported by `mypy` is a future PR.)
How to test: try out the instructions in the `README.md` file.