### PR TITLE
Add dependabot.yaml to check dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - assignees:
+      - "tvogels01"
+    directory: "/"
+    open-pull-requests-limit: 3
+    package-ecosystem: "pip"
+    reviewers:
+      - "data-eng"
+    schedule:
+      day: "tuesday"
+      interval: "weekly"


### PR DESCRIPTION
In order to check our `requirments.txt` files to see what's out of date, this adds a configuration for Dependabot.