### PR TITLE
Add support for dates in JSON logging

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,7 +19,7 @@ indent_style = space
 tab_width = 4
 trim_trailing_whitespace = true
 
-[*.{yaml,yml}]
+[*.{json,yaml,yml}]
 indent_size = 2
 indent_style = space
 tab_width = 2

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -1,0 +1,26 @@
+# Simple workflow to run unit tests.
+
+name: Unit Tests
+
+on:
+  push:
+    paths:
+    - ".github/workflows/unittest.yaml"
+    - "cloudwatch_logs/cw_logs_to_es/**"
+    - "json_logging/**"
+
+jobs:
+  unittest-json-logging:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout out code
+      uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Run unit tests
+      run: |-
+        cd json_logging/
+        python3 setup.py develop
+        python3 -m unittest discover -v tests/

--- a/json_logging/README.md
+++ b/json_logging/README.md
@@ -4,19 +4,33 @@ The package `json_logging` supports regular Python logging to be formatted as
 JSON which makes it much easier to poss-process, for example, by loading log
 lines into an Elasticsearch cluster.
 
+## Fields
+
+These are the default fields that are logged:
+
+Name | Example value | Notes
+----|----|----
+`aws_request_id` | | Request id when executing a function in AWS
+`gmtime` | `2020-08-02T15:24:59.154Z` | Timestamp in RFC3339 format
+`log_level` | `INFO` | Log level as string
+`log_severity` | 20 | Log level as number
+`logger` | `mod.func` | Name of the logger, usually set using `__name__`
+`message` | `Doing work` | Log message
+`process.id` | 75478 | Id of the process running the application
+`process.name` | `MainProcess` | Name of the process running the application
+`source.filename` | `example.py` | File where we logged
+`source.function` | `do_something` | Name of the function within which we logged
+`source.line_number` | 42 | Where in the source file we logged
+`source.module` | `example` | Name of the module (which may be less unique than the filename)
+`source.pathname` | `python/src/example.py` | Location of the source file in the package
+`thread.name` | `MainThread` | Name of the thread
+`timestamp` | 1596381899154 | Epoch milliseconds
+
 ## Installation
 
 Add this line to your `requirements.txt` file:
 ```text
 git+https://github.com/harrystech/arthur-tools.git#subdirectory=json_logging&egg=json-logging
-```
-
-You can also test the installation by calling `pip` directly. (You should
-probably do so inside a Docker container or using a virtual environment.)
-```shell
-python3 -m venv venv
-source venv/bin/activate
-python3 -m pip install --upgrade 'git+https://github.com/harrystech/arthur-tools.git@add-json-logging-package#subdirectory=json_logging&egg=json-logging'
 ```
 
 ## Usage
@@ -63,28 +77,24 @@ logger.info(f"Finished processing {num_count} file(s)", extra={"file_count": num
 
 #### Context wrapper
 
-Log an exception along with a stracktrace like so:
+Log an exception along with a strack trace like so:
 ```python
 with json_logging.log_stack_trace(logger):
     do_something_dangerous()
 ```
 
-## Fields
+## Development
 
-Name | Example value | Notes
-----|----|----
-`aws_request_id` | | Request id when executing a function in AWS
-`gmtime` | `2020-08-02T15:24:59.154Z` | Timestamp in RFC3339 format
-`log_level` | `INFO` | Log level as string
-`log_severity` | 20 | Log level as number
-`logger` | `mod.func` | Name of the logger, usually set using `__name__`
-`message` | `Doing work` | Log message
-`process.id` | 75478 | Id of the process running the application
-`process.name` | `MainProcess` | Name of the process running the application
-`source.filename` | `example.py` | File where we logged
-`source.function` | `do_something` | Name of the function within which we logged
-`source.line_number` | 42 | Where in the source file we logged
-`source.module` | `example` | Name of the module (which may be less unique than the filename)
-`source.pathname` | `python/src/example.py` | Location of the source file in the package
-`thread.name` | `MainThread` | Name of the thread
-`timestamp` | 1596381899154 | Epoch milliseconds
+You can also test the installation by calling `pip` directly. (You should
+probably do so inside a Docker container or using a virtual environment.)
+```shell script
+python3 -m venv venv
+source venv/bin/activate
+python3 -m pip install --upgrade 'git+https://github.com/harrystech/arthur-tools.git@add-json-logging-package#subdirectory=json_logging&egg=json-logging'
+```
+
+### Running unit tests
+
+```shell script
+python3 -m unittest discover tests
+```

--- a/json_logging/README.md
+++ b/json_logging/README.md
@@ -100,7 +100,7 @@ probably do so inside a Docker container or using a virtual environment.)
 ```shell script
 python3 -m venv venv
 source venv/bin/activate
-python3 -m pip install --upgrade 'git+https://github.com/harrystech/arthur-tools.git@add-json-logging-package#subdirectory=json_logging&egg=json-logging'
+python3 -m pip install --upgrade 'git+https://github.com/harrystech/arthur-tools.git@next#subdirectory=json_logging&egg=json-logging'
 ```
 
 ### Running unit tests

--- a/json_logging/README.md
+++ b/json_logging/README.md
@@ -1,8 +1,8 @@
 # JSON-formatted Logging
 
 The package `json_logging` supports regular Python logging to be formatted as
-JSON which makes it much easier to poss-process, for example, by loading log
-lines into an Elasticsearch cluster.
+JSON which makes it much easier to post-process, for example, by loading log
+lines into an Elasticsearch cluster or by defining metrics in CloudWatch.
 
 ## Fields
 
@@ -60,16 +60,25 @@ def handle_event(event, context):
         aws_request_id=context.aws_request_id,
         function_name=context.function_name,
         function_version=context.function_version,
+        invoked_function_arn=context.invoked_function_arn,
         log_stream_name=context.log_stream_name,
     )
     logger.info(f"Starting {__name__}", extra={"event": event})
 ```
 
-### Additional info
+### "Library" code
+
+Outside the main module where you configure the logger, the pattern is:
+```python
+import json_logging
+
+logger = json_logging.getLogger(__name__)
+logger.addHandler(json_logging.NullHandler())
+```
 
 ### "Extra" information
 
-You can send information into the log record using the `extra` kwarg, which
+You can send additional information into the log record using the `extra` kwarg, which
 avoids having to process the message later:
 ```python
 logger.info(f"Finished processing {num_count} file(s)", extra={"file_count": num_count})
@@ -82,6 +91,7 @@ Log an exception along with a strack trace like so:
 with json_logging.log_stack_trace(logger):
     do_something_dangerous()
 ```
+(Note that this doesn't "catch" the exception.)
 
 ## Development
 
@@ -96,5 +106,7 @@ python3 -m pip install --upgrade 'git+https://github.com/harrystech/arthur-tools
 ### Running unit tests
 
 ```shell script
+cd json_logging
 python3 -m unittest discover tests
+python3 json_logging/__init__.py
 ```

--- a/json_logging/setup.py
+++ b/json_logging/setup.py
@@ -8,5 +8,5 @@ setup(
     packages=["json_logging"],
     python_requires=">=3.5",
     url="https://github.com/harrystech/arthur-tools",
-    version="1.0.0",
+    version="1.1.0",
 )

--- a/json_logging/tests/test_json_logging.py
+++ b/json_logging/tests/test_json_logging.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest import TestCase
 
 import json_logging
@@ -7,3 +8,8 @@ class JsonLoggingTests(TestCase):
     def test_simple_example(self):
         logger = json_logging.getLogger("example")
         logger.info("Hello", extra={"more": "stuff"})
+
+    def test_date(self):
+        logger = json_logging.getLogger("example")
+        today = datetime.datetime(2021, 2, 10, 21, 15, 35, 422060)
+        logger.info(f"Today is {today}", extra={"today": datetime.datetime(2021, 2, 10, 21, 15)})

--- a/json_logging/tests/test_json_logging.py
+++ b/json_logging/tests/test_json_logging.py
@@ -1,0 +1,9 @@
+from unittest import TestCase
+
+import json_logging
+
+
+class JsonLoggingTests(TestCase):
+    def test_simple_example(self):
+        logger = json_logging.getLogger("example")
+        logger.info("Hello", extra={"more": "stuff"})


### PR DESCRIPTION
This PR fixes an issue with JSON logging where a datetime in the "extra"s trips up the logger.

For testing, use:
```
python3 -m pip install --upgrade 'git+https://github.com/harrystech/arthur-tools.git@support-dates-in-json#subdirectory=json_logging&egg=json-logging'
```