### PR TITLE
Add intermediate files in S3

### DIFF
--- a/logging/README.md
+++ b/logging/README.md
@@ -54,8 +54,10 @@ to bring up a ES domain along with a Lambda function to load log files.
 For example:
 ```bash
 ../bin/do_cloudformation.sh create dw_es_domain dev \
+    CodeS3Bucket="<your code bucket>" \
+    CodeS3Key="<your latest zip file>" \
     DomainName="dw-es-dev" \
-    CodeS3Bucket="<your code bucket>" CodeS3Key="<your latest zip file>" \
+    EnvName="dev" \
     NodeStorageSize=20 \
     WhitelistCIDR1=192.168.1.1/32
 ```
@@ -64,10 +66,17 @@ Replace the IP address with your actual office IP address.
 If you need to update the stack, e.g. to update the Lambda handler, modify this line appropriately:
 ```bash
 ../bin/do_cloudformation.sh update dw_es_domain dev \
+    CodeS3Bucket=UsePreviousValue \
+    CodeS3Key=UsePreviousValue \
     DomainName=UsePreviousValue \
-    CodeS3Bucket=UsePreviousValue CodeS3Key=UsePreviousValue \
+    ElasticsearchVersion=UsePreviousValue \
+    EnvName=UsePreviousValue \
+    InstanceType=UsePreviousValue \
+    NodeCount=UsePreviousValue \
     NodeStorageSize=UsePreviousValue \
     WhitelistCIDR1=UsePreviousValue
+    WhitelistCIDR2=UsePreviousValue \
+    WhitelistCIDR3=UsePreviousValue
 ```
 Remember that once you have set an optional parameter, you have to at least pass in that parameter
 with `=UserPreviousValue` or it reverts to its default.

--- a/logging/log_processing/upload.py
+++ b/logging/log_processing/upload.py
@@ -97,7 +97,8 @@ def lambda_handler(event, context):
         file_uri = f"s3://{bucket_name}/{object_key}"
         if not (
             (object_key.startswith("_logs/") or "/logs/" in object_key)
-            and object_key.endswith(("StdError.gz", "stderr.gz"))
+            and object_key.endswith(".gz")
+            and "stderr" in object_key.lower()
         ):
             event_logger.info(f"Object is not a log file: {file_uri}")
             continue


### PR DESCRIPTION
The log files are getting large and partial log files land in S3. We need to pull the intermediate files so that we don't just end up with the last few minutes.