### PR TITLE
Improve JSON logging: add pretty output, add elapsed_ms, fix timestamps

### DIFF
--- a/json_logging/README.md
+++ b/json_logging/README.md
@@ -10,10 +10,11 @@ These are the default fields that are logged:
 
 Name | Example value | Notes
 ----|----|----
-`aws_request_id` | | Request id when executing a function in AWS
+`aws_request_id` | `799ab13f-6d11-4f0d-853f-bad9fcad86c3` | Request id when executing a function in AWS
+`elapsed_ms` | 24 | Elapsed time in milliseconds (since module was loaded)
 `gmtime` | `2020-08-02T15:24:59.154Z` | Timestamp in RFC3339 format
 `log_level` | `INFO` | Log level as string
-`log_severity` | 20 | Log level as number
+`log_severity` | 20 | Log level as number which makes it easy to filter
 `logger` | `mod.func` | Name of the logger, usually set using `__name__`
 `message` | `Doing work` | Log message
 `process.id` | 75478 | Id of the process running the application
@@ -22,20 +23,43 @@ Name | Example value | Notes
 `source.function` | `do_something` | Name of the function within which we logged
 `source.line_number` | 42 | Where in the source file we logged
 `source.module` | `example` | Name of the module (which may be less unique than the filename)
-`source.pathname` | `python/src/example.py` | Location of the source file in the package
-`thread.name` | `MainThread` | Name of the thread
+`source.pathname` | `python/src/example.py` | Location of the source file
+`thread.name` | `MainThread` | Name of the running thread
 `timestamp` | 1596381899154 | Epoch milliseconds
+
+The fields were chosen to make it easy to collect the logs
+into a system where we can search, trace and alert.
+
+Either the `gmtime` or `timestamp` will allow sorting of log lines.
+
+The output is normally one record per line. This allows treating the logs
+as [JSONL](https://jsonlines.org/) and makes it easy to consume.
+
+For development work, it is sometimes preferred to pretty-print the log,
+similar to what you would see in CloudWatch logs when viewing log lines
+that are JSON-formatted. Use `pretty=True` when configuring logging
+to turn on this mode.
+```shell
+python3 example.py --pretty
+```
 
 ## Installation
 
-Add this line to your `requirements.txt` file:
+Add this line to your `requirements.txt` file to pull the `main` version:
 ```text
 git+https://github.com/harrystech/arthur-tools.git#subdirectory=json_logging&egg=json-logging
 ```
 
+To use a specific version or the latest developer version, change this to:
+```text
+git+https://github.com/harrystech/arthur-tools.git@next#subdirectory=json_logging&egg=json-logging
+```
+
+The syntax is described in the [documentation of `pip`](https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support).
+
 ## Usage
 
-### General use in applications
+### General Use In Applications
 
 Add something like this to your code:
 ```python
@@ -43,15 +67,22 @@ import json_logging
 
 json_logging.configure_logging()
 logger = json_logging.getLogger(__name__)
+
 logger.info("Hello World!")
 ```
 
-### Use for Lambda functions
+### Use For Lambda Functions
+
+The code example below
+* configures logging in the module that is called by AWS Lambda
+* uses the pretty-printed output but only in local testing
+* copies the values from the context at runtime
 
 ```python
 import json_logging
 
 json_logging.configure_logging()
+json_logging.set_output_format(pretty_if_tty=True)
 logger = json_logging.getLogger(__name__)
 
 
@@ -66,7 +97,7 @@ def handle_event(event, context):
     logger.info(f"Starting {__name__}", extra={"event": event})
 ```
 
-### "Library" code
+### Library Code
 
 Outside the main module where you configure the logger, the pattern is:
 ```python
@@ -76,7 +107,7 @@ logger = json_logging.getLogger(__name__)
 logger.addHandler(json_logging.NullHandler())
 ```
 
-### "Extra" information
+### "Extra" Information
 
 You can send additional information into the log record using the `extra` kwarg, which
 avoids having to process the message later:
@@ -84,20 +115,22 @@ avoids having to process the message later:
 logger.info(f"Finished processing {num_count} file(s)", extra={"file_count": num_count})
 ```
 
-#### Context wrapper
+### Context Wrapper
 
-Log an exception along with a strack trace like so:
+Log an exception along with a stack trace like so:
 ```python
 with json_logging.log_stack_trace(logger):
     do_something_dangerous()
 ```
-(Note that this doesn't "catch" the exception.)
+
+Note that this doesn't "catch" the exception.
 
 ## Development
 
 You can also test the installation by calling `pip` directly. (You should
 probably do so inside a Docker container or using a virtual environment.)
-```shell script
+```shell
+cd json_logging
 python3 -m venv venv
 source venv/bin/activate
 python3 -m pip install --upgrade 'git+https://github.com/harrystech/arthur-tools.git@next#subdirectory=json_logging&egg=json-logging'
@@ -105,8 +138,8 @@ python3 -m pip install --upgrade 'git+https://github.com/harrystech/arthur-tools
 
 ### Running unit tests
 
-```shell script
-cd json_logging
+```shell
+python3 -m pip install --upgrade --editable .
+
 python3 -m unittest discover tests
-python3 json_logging/__init__.py
 ```

--- a/json_logging/README.md
+++ b/json_logging/README.md
@@ -68,10 +68,11 @@ import json_logging
 json_logging.configure_logging()
 logger = json_logging.getLogger(__name__)
 
+json_logging.update_context(request_id='abcde-12345')
 logger.info("Hello World!")
 ```
 
-### Use For Lambda Functions
+### Use For AWS Lambda Functions
 
 The code example below
 * configures logging in the module that is called by AWS Lambda
@@ -87,13 +88,7 @@ logger = json_logging.getLogger(__name__)
 
 
 def handle_event(event, context):
-    json_logging.update_context(
-        aws_request_id=context.aws_request_id,
-        function_name=context.function_name,
-        function_version=context.function_version,
-        invoked_function_arn=context.invoked_function_arn,
-        log_stream_name=context.log_stream_name,
-    )
+    json_logging.update_from_lambda_context(context)
     logger.info(f"Starting {__name__}", extra={"event": event})
 ```
 

--- a/json_logging/example.py
+++ b/json_logging/example.py
@@ -1,0 +1,33 @@
+import argparse
+
+import json_logging
+
+logger = json_logging.getLogger(__name__)
+
+
+def main_test() -> None:
+    json_logging.update_context(aws_request_id="62E538E9-E9C5-415A-9771-6588F9A1A708")
+    logger.info("Message at INFO level")
+    logger.debug("Message at DEBUG level")
+
+    num_count = 99
+    logger.info(
+        f"Finished counting {num_count} balloons", extra={"metrics": {"num_balloons": num_count}}
+    )
+
+    with json_logging.log_stack_trace(logger):
+        raise RuntimeError("example exception")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--verbose", action="store_true")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--pretty-print", action="store_true", dest="pretty")
+    group.add_argument("--compact", action="store_false", dest="pretty")
+    args = parser.parse_args()
+
+    json_logging.configure_logging("DEBUG" if args.verbose else "INFO")
+    json_logging.set_output_format(pretty=args.pretty)
+
+    main_test()

--- a/json_logging/example.py
+++ b/json_logging/example.py
@@ -1,5 +1,6 @@
 import argparse
 import uuid
+from datetime import datetime, timezone
 
 import json_logging
 
@@ -11,9 +12,12 @@ def main() -> None:
     logger.debug("Message at DEBUG level")
 
     num_count = 99
-    logger.info(
+    logger.warning(
         f"Finished counting {num_count} balloons", extra={"metrics": {"num_balloons": num_count}}
     )
+    # The date in the extra field will be in ISO 8601 (with 'T' separator and timzeone).
+    now = datetime.now(timezone.utc)
+    logger.info("Started now at: %s (using default __str__())", now, extra={"utcnow": now})
 
     with json_logging.log_stack_trace(logger):
         raise RuntimeError("example exception")

--- a/json_logging/example.py
+++ b/json_logging/example.py
@@ -1,12 +1,12 @@
 import argparse
+import uuid
 
 import json_logging
 
 logger = json_logging.getLogger(__name__)
 
 
-def main_test() -> None:
-    json_logging.update_context(aws_request_id="62E538E9-E9C5-415A-9771-6588F9A1A708")
+def main() -> None:
     logger.info("Message at INFO level")
     logger.debug("Message at DEBUG level")
 
@@ -29,5 +29,6 @@ if __name__ == "__main__":
 
     json_logging.configure_logging("DEBUG" if args.verbose else "INFO")
     json_logging.set_output_format(pretty=args.pretty)
+    json_logging.update_context(request_id=uuid.uuid4().hex)
 
-    main_test()
+    main()

--- a/json_logging/json_logging/__init__.py
+++ b/json_logging/json_logging/__init__.py
@@ -7,15 +7,12 @@ Since we assume this will be used by Lambda functions, we also add the request i
 import json
 import logging
 import logging.config
+import sys
 import time
 import traceback
 from contextlib import ContextDecorator
-from logging import NullHandler
-
-
-# Just for developer convenience -- this avoids having too many imports of "logging" packages.
-def getLogger(name: str) -> logging.Logger:
-    return logging.getLogger(name)
+from logging import NullHandler  # noqa: F401
+from typing import Dict, Optional, Tuple, Union
 
 
 class ContextFilter(logging.Filter):
@@ -26,8 +23,8 @@ class ContextFilter(logging.Filter):
     means that we will store some values with the class, not the instances.
     """
 
-    _context = {
-        "aws_request_id": "UNKNOWN",  # mypy stumbles on all values being None
+    _context: Dict[str, Optional[str]] = {
+        "aws_request_id": None,
         "function_name": None,
         "function_version": None,
         "invoked_function_arn": None,
@@ -45,7 +42,7 @@ class ContextFilter(logging.Filter):
     @classmethod
     def update_context(cls, **kwargs: str) -> None:
         """
-        Update any of the fields stored in the (global) context filter.
+        Update any of the fields stored in the global context filter.
 
         Note that trying to set a field that's not been defined raises a ValueError.
         """
@@ -88,8 +85,9 @@ class JsonFormatter(logging.Formatter):
         "function_name": "lambda.function_name",
         "function_version": "lambda.function_version",
         "invoked_function_arn": "lambda.invoked_function_arn",
+        "log_group_name": "cwl.log_group_name",
         "log_stream_name": "cwl.log_stream_name",
-        # LogRecord attributes which we want to suppress:
+        # LogRecord attributes which we want to suppress or rewrite ourselves:
         "args": None,
         "created": None,
         "msecs": None,
@@ -98,30 +96,46 @@ class JsonFormatter(logging.Formatter):
         "thread": None,
     }
 
+    # Use "set_output_format()" to change this value.
+    output_format = "compact"
+
+    @property
+    def indent(self) -> Optional[str]:
+        return {"compact": None, "pretty": "    "}[self.output_format]
+
+    @property
+    def separators(self) -> Tuple[str, str]:
+        return {"compact": (",", ":"), "pretty": (",", ": ")}[self.output_format]
+
     def format(self, record: logging.LogRecord) -> str:
         """Format log record by creating a JSON-format in a string."""
-        data = {}
+        assembled = {}
         for attr, value in record.__dict__.items():
             if value is None:
                 continue
             if attr in self.attribute_mapping:
                 new_name = self.attribute_mapping[attr]
                 if new_name is not None:
-                    data[new_name] = value
+                    assembled[new_name] = value
             else:
-                data[attr] = value
+                assembled[attr] = value
         # The "message" is added last so an accidentally specified message in the extra kwargs
         # is ignored.
-        data["message"] = record.getMessage()
+        assembled["message"] = record.getMessage()
+        # We show elapsed milliseconds as int, not float.
+        assembled["elapsed_ms"] = int(record.relativeCreated)
         # Finally, always add a timestamp as epoch msecs and in a human readable format.
         # (Go to https://www.epochconverter.com/ to convert the timestamp in milliseconds.)
-        data["timestamp"] = int(record.created * 1000.0)
-        data["gmtime"] = self.formatTime(record)
-        return json.dumps(data, default=str, separators=(",", ":"), sort_keys=True)
+        assembled["timestamp"] = int(record.created * 1000.0)
+        assembled["gmtime"] = self.formatTime(record)
+        # TODO(tom): Use custom class with cls= to dump dates.
+        return json.dumps(
+            assembled, default=str, indent=self.indent, separators=self.separators, sort_keys=True
+        )
 
 
-# We don't create the config dict until here so that we can use the classes
-# (instead of class names in strings).
+# We don't create this dict earlier so that we can use the classes (instead of their names
+# as strings).
 LOGGING_STREAM_CONFIG = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -161,11 +175,27 @@ LOGGING_STREAM_CONFIG = {
 }
 
 
-def configure_logging() -> None:
+def configure_logging(level: Union[int, str] = "INFO") -> None:
+    """Configure logging module to use JSON formatter for logs."""
     logging.config.dictConfig(LOGGING_STREAM_CONFIG)
+    logging.captureWarnings(True)
+    logging.root.setLevel(level)
+
+
+# Just for developer convenience -- this avoids having too many imports of "logging" packages.
+def getLogger(name: str = None) -> logging.Logger:
+    return logging.getLogger(name)
+
+
+def set_output_format(pretty: bool = False, pretty_if_tty: bool = False) -> None:
+    if pretty or (pretty_if_tty and sys.stdout.isatty()):
+        JsonFormatter.output_format = "pretty"
+    else:
+        JsonFormatter.output_format = "compact"
 
 
 def update_context(**kwargs: str) -> None:
+    """Update values in the logging context to be included with every log record."""
     ContextFilter.update_context(**kwargs)
 
 
@@ -180,24 +210,9 @@ class log_stack_trace(ContextDecorator):
 
     def __exit__(self, exc_type, exc_val, exc_tb):  # type: ignore
         if exc_type:
+            stack_trace_output = "".join(traceback.format_exception(exc_type, exc_val, exc_tb))
             self._logger.error(
                 f"Exception: {exc_val!r}",
-                extra={"stack_trace": traceback.format_exception(exc_type, exc_val, exc_tb)},
+                extra={"stack_trace": stack_trace_output.splitlines()},
             )
         return None
-
-
-def main_test() -> None:
-    configure_logging()
-    logger = getLogger(__name__)
-    logger.addHandler(NullHandler())
-
-    update_context(aws_request_id="62E538E9-E9C5-415A-9771-6588F9A1A708")
-    logging.info("Message at INFO level", extra={"planet": "earth"})
-
-    num_count = 99
-    logger.info(f"Finished counting {num_count} balloons", extra={"balloons": num_count})
-
-
-if __name__ == "__main__":
-    main_test()

--- a/json_logging/setup.py
+++ b/json_logging/setup.py
@@ -6,7 +6,7 @@ setup(
     license="MIT",
     name="json_logging",
     packages=["json_logging"],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     url="https://github.com/harrystech/arthur-tools",
-    version="1.1.0",
+    version="1.2.0",
 )

--- a/json_logging/tests/test_json_logging.py
+++ b/json_logging/tests/test_json_logging.py
@@ -1,15 +1,68 @@
 import datetime
+import json
 from unittest import TestCase
 
 import json_logging
 
 
 class JsonLoggingTests(TestCase):
-    def test_simple_example(self) -> None:
-        logger = json_logging.getLogger("example")
-        logger.info("Hello", extra={"more": "stuff"})
+    def setUp(self) -> None:
+        json_logging.configure_logging()
+        self.filter = json_logging.ContextFilter()
+        self.formatter = json_logging.JsonFormatter()
+        self.logger = json_logging.getLogger("unittest")
 
-    def test_date(self) -> None:
-        logger = json_logging.getLogger("example")
-        today = datetime.datetime(2021, 2, 10, 21, 15, 35, 422060)
-        logger.info(f"Today is {today}", extra={"today": datetime.datetime(2021, 2, 10, 21, 15)})
+    def _setup_logger(self) -> None:
+        # Within a context, the handler is replaced by a "capturing handler" from unittest.
+        # So we must bring back our filter and formatter.
+        for handler in self.logger.handlers:
+            handler.addFilter(self.filter)
+            handler.setFormatter(self.formatter)
+
+    def test_keys(self) -> None:
+        """Checking whether keys are present."""
+        with self.assertLogs(self.logger) as cm:
+            self._setup_logger()
+            self.logger.info("Hello World")
+        parsed = json.loads(cm.output[0])
+
+        # Just testing the most basic keys for now.
+        for key in ["elapsed_ms", "gmtime", "log_level", "message", "timestamp"]:
+            with self.subTest(key=key):
+                self.assertIn(key, parsed)
+                self.assertIsNotNone(parsed[key])
+
+    def test_passing_extras(self) -> None:
+        """Checking whether we can pass extra dict."""
+        with self.assertLogs(self.logger) as cm:
+            self._setup_logger()
+            self.logger.info("Saving metrics", extra={"metrics": {"count": 1}})
+        parsed = json.loads(cm.output[0])
+
+        self.assertIn("metrics", parsed)
+        self.assertDictEqual(parsed["metrics"], {"count": 1})
+
+    def test_request_id(self) -> None:
+        """Checking whether we can set a request id."""
+        with self.assertLogs(self.logger) as cm:
+            self._setup_logger()
+            json_logging.update_context(request_id="test-123")
+            self.logger.info("test request_id")
+        parsed = json.loads(cm.output[0])
+
+        self.assertIn("request_id", parsed)
+        self.assertEqual(parsed["request_id"], "test-123")
+
+    def test_aware_datetime(self) -> None:
+        """Checking whether datetime (with timezone) is correctly formatted."""
+        sometime = datetime.datetime(
+            year=2021, month=3, day=14, hour=15, minute=9, tzinfo=datetime.timezone.utc
+        )
+        with self.assertLogs(self.logger) as cm:
+            self._setup_logger()
+            self.logger.info("Adding aware date", extra={"pi_day": sometime})
+        parsed = json.loads(cm.output[0])
+
+        self.assertIn("pi_day", parsed)
+        # Apologies for the extra 0s.
+        self.assertEqual(parsed["pi_day"], "2021-03-14T15:09:00.000Z")

--- a/json_logging/tests/test_json_logging.py
+++ b/json_logging/tests/test_json_logging.py
@@ -5,11 +5,11 @@ import json_logging
 
 
 class JsonLoggingTests(TestCase):
-    def test_simple_example(self):
+    def test_simple_example(self) -> None:
         logger = json_logging.getLogger("example")
         logger.info("Hello", extra={"more": "stuff"})
 
-    def test_date(self):
+    def test_date(self) -> None:
         logger = json_logging.getLogger("example")
         today = datetime.datetime(2021, 2, 10, 21, 15, 35, 422060)
         logger.info(f"Today is {today}", extra={"today": datetime.datetime(2021, 2, 10, 21, 15)})


### PR DESCRIPTION
Tweaks to the output of logs to make our life's better:
* Output dict now contains `elapsed_ms` to make it easier to judge relative time in log lines.
* The field `request_id` can be set and is an alternative to `aws_request_id` when not running a Lambda function.
* For configuring logging of a Lambda function, `update_from_lambda_context()` should now be used instead of updating individual fields.
* `datetime` objects are now formatted closer to ISO 8601 to make them easier to digest downstream.
* "Pretty printing" of log lines is available which makes logs easier to read for local development.
    * See output of `python3 example.py --pretty`
    * Using `set_output_format(pretty_if_tty=True)` is compatible with deployments into AWS Lambda where logging will revert back to the compact format when logs are sent to CloudWatch.