### PR TITLE
Add pre-commit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,12 @@ end_of_line = lf
 insert_final_newline = true
 max_line_length = 100
 
+[*.json]
+indent_size = 4
+indent_style = space
+tab_width = 4
+trim_trailing_whitespace = true
+
 [*.md]
 indent_size = 4
 indent_style = space
@@ -13,13 +19,19 @@ max_line_length = 80
 tab_width = 4
 trim_trailing_whitespace = true
 
-[*.{py,sh}]
+[*.py]
 indent_size = 4
 indent_style = space
 tab_width = 4
 trim_trailing_whitespace = true
 
-[*.{json,yaml,yml}]
+[*.sh]
+indent_size = 2
+indent_style = space
+tab_width = 2
+trim_trailing_whitespace = true
+
+[*.yaml,yml]
 indent_size = 2
 indent_style = space
 tab_width = 2

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,16 @@
+name: Run pre-commit hooks against all files
+
+on:
+  push:
+    paths:
+    - ".github/workflows/pre-commit.yaml"
+    - "cloudwatch_logs/**"
+    - "json_logging/**"
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,4 @@ ENV/
 
 # Mac stuff
 .DS_Store
-.idea
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,60 @@
+exclude: "^bin/|^cloudformation/|^logging/"
+
+# Hooks are sorted to go from some basic stuff
+# to more and more complex tests.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-symlinks
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: requirements-txt-fixer
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.26.0
+    hooks:
+      - id: yamllint
+  - repo: https://github.com/aws-cloudformation/cfn-python-lint
+    rev: v0.45.0
+    hooks:
+      - id: cfn-python-lint
+        files: cloudformation/.*\.(json|yml|yaml)$
+  - repo: https://github.com/PrincetonUniversity/blocklint
+    rev: v0.2.3
+    hooks:
+      - id: blocklint
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.7.1
+    hooks:
+      - id: python-check-blanket-noqa
+      - id: python-use-type-annotations
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.10.0
+    hooks:
+      - id: pyupgrade
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.7.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - "flake8-docstrings==1.5.0"
+          - "flake8-fixme==1.1.1"
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.812
+    hooks:
+      - id: mypy
+        additional_dependencies: [mypy-boto3==1.16.0]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.7.1.1
+    hooks:
+      - id: shellcheck

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,20 @@
+extends: default
+
+rules:
+
+  document-end:
+    present: false
+
+  document-start:
+    present: false
+
+  indentation:
+    spaces: 2
+    indent-sequences: consistent
+
+  line-length:
+    max: 100
+    level: warning
+
+  truthy:
+    check-keys: false

--- a/cloudwatch_logs/bin/run_me.sh
+++ b/cloudwatch_logs/bin/run_me.sh
@@ -67,7 +67,7 @@ docker_aws_put_subscription_filter () {
         --statement-id "$(uuidgen)"
 
     docker_aws logs put-subscription-filter \
-        --log-group-name $LOG_GROUP_NAME \
+        --log-group-name "$LOG_GROUP_NAME" \
         --filter-name "Lambda_$FUNCTION_NAME" \
         --filter-pattern "" \
         --destination-arn "$DESTINATION_ARN"
@@ -82,7 +82,7 @@ docker_build () {
 
 docker_run () {
     set -o xtrace
-    docker run --rm --interactive --tty --volume "$PWD/$PROJ_NAME":"/var/task/$PROJ_NAME" \
+    docker run --rm --interactive --tty --volume "$PWD/$PROJ_NAME:/var/task/$PROJ_NAME" \
         --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN \
         --env AWS_REGION --env AWS_DEFAULT_REGION --env ES_DOMAIN_NAME \
         "$PROJ_NAME":latest "$@"
@@ -98,7 +98,7 @@ case $cmd in
         ;;
     'add-subscription')
         LOG_GROUP_NAME="${1?You need to specify a log group name as arg}"
-        docker_aws_put_subscription_filter $LOG_GROUP_NAME
+        docker_aws_put_subscription_filter "$LOG_GROUP_NAME"
         ;;
     'build')
         docker_build

--- a/json_logging/tests/test_json_logging.py
+++ b/json_logging/tests/test_json_logging.py
@@ -5,11 +5,11 @@ import json_logging
 
 
 class JsonLoggingTests(TestCase):
-    def test_simple_example(self):
+    def test_simple_example(self) -> None:
         logger = json_logging.getLogger("example")
         logger.info("Hello", extra={"more": "stuff"})
 
-    def test_date(self):
+    def test_date(self) -> None:
         logger = json_logging.getLogger("example")
         today = datetime.datetime(2021, 2, 10, 21, 15, 35, 422060)
         logger.info(f"Today is {today}", extra={"today": datetime.datetime(2021, 2, 10, 21, 15)})

--- a/requirements-linters.txt
+++ b/requirements-linters.txt
@@ -1,3 +1,4 @@
+# For now, we sync them manually with pre-commit.
 black==20.8b1
 flake8==3.8.4
 flake8-docstrings==1.5.0


### PR DESCRIPTION
This PR adds `pre-commit` to this repo so that we can run linters etc. automatically. 
There are also a few code changes to accommodate `shellcheck`.
A somewhat more forgiving `.yamllint` comes along.

While this PR adds a workflow for `pre-commit`, it doesn't turn off the current setup so that we can test them in parallel.