### PR TITLE
Add "correlation_id" to the logging context

### DIFF
--- a/json_logging/README.md
+++ b/json_logging/README.md
@@ -11,7 +11,8 @@ These are the default fields that are logged:
 Name | Example value | Notes
 ----|----|----
 `aws_request_id` | `799ab13f-6d11-4f0d-853f-bad9fcad86c3` | Request id when executing a function in AWS
-`elapsed_ms` | 24 | Elapsed time in milliseconds (since module was loaded)
+`correlation_id` | `80bd63b7-d91e-4b8c-b60b-3ad83606d144` | Optional id that allows us to pull mutiple requests together
+`elapsed_ms` | 24 | Elapsed time in milliseconds (since module was loaded, which is time of cold-start for AWS Lambda)
 `gmtime` | `2020-08-02T15:24:59.154Z` | Timestamp in RFC3339 format
 `log_level` | `INFO` | Log level as string
 `log_severity` | 20 | Log level as number which makes it easy to filter

--- a/json_logging/json_logging/__init__.py
+++ b/json_logging/json_logging/__init__.py
@@ -25,6 +25,7 @@ class ContextFilter(logging.Filter):
 
     _context: Dict[str, Optional[str]] = {
         "aws_request_id": None,
+        "correlation_id": None,
         "function_name": None,
         "function_version": None,
         "invoked_function_arn": None,
@@ -47,11 +48,12 @@ class ContextFilter(logging.Filter):
             cls._context[field] = getattr(context, field, value)
 
     @classmethod
-    def update_context(cls, **kwargs: str) -> None:
+    def update_context(cls, **kwargs: Optional[str]) -> None:
         """
         Update any of the fields stored in the global context filter.
 
         Note that trying to set a field that's not been defined raises a ValueError.
+        Setting a field to None removes it from the output.
         """
         for field, value in kwargs.items():
             if field in cls._context:


### PR DESCRIPTION
Adding another field to the logging context. So if a task is broken down into multiple steps we can later bind them together. An example is a task that is sent to SQS as multiple messages where each message then triggers an AWS Lambda function. Each function call gives us a new "aws request id" but we also want to be able to look them up together as a set of functions.

Example use in AWS CloudWatch Logs Insights:
```
filter correlation_id = "03df790a-2e9c-46c4-8911-d12b90f04bd7"
| fields @timestamp, aws_request_id, message
| sort @timestamp desc
| limit 20
```

Example code that shows tracking by message ID:
```
def handle_event(event, context): 
    json_logging.update_from_lambda_context(context)
    with json_logging.log_stack_trace(logger):
        for record in event["Records"]:
            json_logging.update_context(correlation_id=record["messageId"])
```