### PR TITLE
Remove "tvogels01" as assignee, fix team name in reviewers

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,12 +1,10 @@
 version: 2
 updates:
-  - assignees:
-      - "tvogels01"
-    directory: "/"
+  - directory: "/"
     open-pull-requests-limit: 3
     package-ecosystem: "pip"
     reviewers:
-      - "harrystech/data-eng"
+      - "harrystech/data-platform"
     schedule:
       day: "tuesday"
       interval: "weekly"


### PR DESCRIPTION
This drops my personal account as an assignee for PRs from dependabot.
This also fixes the team name to `data-platform`.